### PR TITLE
test: expand backend unit coverage

### DIFF
--- a/backend/tests/test_action_registry_unit.py
+++ b/backend/tests/test_action_registry_unit.py
@@ -1,0 +1,143 @@
+"""Focused unit tests for action registration and resolution."""
+
+from stash_ai_server.actions.models import ActionDefinition, ContextInput, ContextRule
+from stash_ai_server.actions.registry import ActionRegistry, action, collect_actions
+
+
+def _definition(
+    *,
+    action_id: str = "example",
+    selection: str = "single",
+    service: str = "service-a",
+) -> ActionDefinition:
+    return ActionDefinition(
+        id=action_id,
+        label=f"{action_id}-{selection}",
+        service=service,
+        contexts=[ContextRule(pages=["scenes"], selection=selection)],
+    )
+
+
+def test_registry_lists_registered_actions_in_order():
+    registry = ActionRegistry()
+    first_handler = lambda *_: "first"
+    second_handler = lambda *_: "second"
+    first = _definition(action_id="first")
+    second = _definition(action_id="second")
+
+    registry.register(first, first_handler)
+    registry.register(second, second_handler)
+
+    assert registry.list_ids() == ["first", "second"]
+    assert registry.list_all() == [first, second]
+    assert registry.all_for_id("first") == [first]
+    assert registry.all_for_id("missing") == []
+
+
+def test_resolve_prefers_definition_matching_view_kind():
+    registry = ActionRegistry()
+    library = _definition(selection="multi")
+    detail = _definition(selection="single")
+    library_handler = lambda *_: "library"
+    detail_handler = lambda *_: "detail"
+    registry.register(library, library_handler)
+    registry.register(detail, detail_handler)
+
+    detail_result = registry.resolve(
+        "example",
+        ContextInput(page="scenes", entity_id="1", is_detail_view=True),
+    )
+    library_result = registry.resolve(
+        "example",
+        ContextInput(page="scenes", selected_ids=["1"], is_detail_view=False),
+    )
+
+    assert detail_result == (detail, detail_handler)
+    assert library_result == (library, library_handler)
+
+
+def test_resolve_uses_applicable_fallback_and_handles_missing_actions():
+    registry = ActionRegistry()
+    generic = ActionDefinition(id="generic", label="Generic", contexts=[])
+    handler = lambda *_: None
+    registry.register(generic, handler)
+
+    context = ContextInput(page="scenes", entity_id="1", is_detail_view=True)
+
+    assert registry.resolve("generic", context) == (generic, handler)
+    assert registry.resolve("missing", context) is None
+    assert registry.resolve(
+        "generic",
+        ContextInput(page="images", is_detail_view=False),
+    ) == (generic, handler)
+
+
+def test_resolve_returns_none_when_no_definition_is_applicable():
+    registry = ActionRegistry()
+    registry.register(_definition(), lambda *_: None)
+
+    assert registry.resolve(
+        "example",
+        ContextInput(page="images", entity_id="1", is_detail_view=True),
+    ) is None
+
+
+def test_unregister_service_preserves_other_definitions_and_handlers():
+    registry = ActionRegistry()
+    removed = _definition(service="remove-me")
+    kept = _definition(service="keep-me")
+    removed_handler = lambda *_: "removed"
+    kept_handler = lambda *_: "kept"
+    registry.register(removed, removed_handler)
+    registry.register(kept, kept_handler)
+
+    registry.unregister_service("")
+    registry.unregister_service("remove-me")
+
+    assert registry.all_for_id("example") == [kept]
+    resolved = registry.resolve(
+        "example",
+        ContextInput(page="scenes", entity_id="1", is_detail_view=True),
+    )
+    assert resolved == (kept, kept_handler)
+
+    registry.unregister_service("keep-me")
+    assert registry.list_ids() == []
+    assert registry.resolve(
+        "example",
+        ContextInput(page="scenes", entity_id="1", is_detail_view=True),
+    ) is None
+
+
+def test_action_decorator_and_collection_preserve_metadata_and_binding():
+    class ExampleService:
+        @action(
+            id="decorated",
+            label="Decorated action",
+            description="Runs a decorated action",
+            service="declared-service",
+            result_kind="dialog",
+            dialog_type="details",
+            contexts=[ContextRule(pages=["scenes"], selection="single")],
+            input_schema={"type": "object"},
+            deduplicate_submissions=False,
+        )
+        def run(self, *_):
+            return "done"
+
+        ignored = "value"
+
+    service = ExampleService()
+    collected = collect_actions(service)
+
+    assert len(collected) == 1
+    definition, handler = collected[0]
+    assert definition.id == "decorated"
+    assert definition.label == "Decorated action"
+    assert definition.description == "Runs a decorated action"
+    assert definition.service == "declared-service"
+    assert definition.result_kind == "dialog"
+    assert definition.dialog_type == "details"
+    assert definition.input_schema == {"type": "object"}
+    assert definition.deduplicate_submissions is False
+    assert handler() == "done"

--- a/backend/tests/test_ai_results_store_unit.py
+++ b/backend/tests/test_ai_results_store_unit.py
@@ -1,0 +1,515 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.orm import sessionmaker
+
+from stash_ai_server.db import ai_results_store
+from stash_ai_server.models.ai_results import AIModel
+from stash_ai_server.models.ai_results import AIModelRun
+from stash_ai_server.models.ai_results import AIModelRunModel
+from stash_ai_server.models.ai_results import AIResultAggregate
+from stash_ai_server.models.ai_results import AIResultTimespan
+
+
+@pytest.fixture
+def result_store_db(tmp_path, monkeypatch):
+    engine = sa.create_engine(f"sqlite+pysqlite:///{tmp_path / 'results.sqlite'}")
+    for table in (
+        AIModel.__table__,
+        AIModelRun.__table__,
+        AIModelRunModel.__table__,
+        AIResultTimespan.__table__,
+        AIResultAggregate.__table__,
+    ):
+        table.create(engine)
+    factory = sessionmaker(bind=engine, expire_on_commit=False)
+    monkeypatch.setattr(ai_results_store, "get_session_local", lambda: factory)
+    try:
+        yield factory
+    finally:
+        engine.dispose()
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (None, None),
+        ("", None),
+        ("4", 4),
+        (5.8, 5),
+        ("bad", None),
+        (object(), None),
+    ],
+)
+def test_ensure_int(value, expected):
+    assert ai_results_store._ensure_int(value) == expected
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [(None, None), ("2.5", 2.5), (3, 3.0), ("bad", None), (object(), None)],
+)
+def test_safe_float(value, expected):
+    assert ai_results_store._safe_float(value) == expected
+
+
+def test_input_and_category_normalizers():
+    assert ai_results_store._prepare_input_params(None) is None
+    assert ai_results_store._prepare_input_params(["not", "mapping"]) is None
+    assert ai_results_store._prepare_input_params(
+        {"null": "null", "nested": {"value": "null"}}
+    ) == {"null": None, "nested": {"value": None}}
+
+    assert ai_results_store._clean_category_list(None) is None
+    assert ai_results_store._clean_category_list("text") is None
+    assert ai_results_store._clean_category_list(
+        [" Actions ", "", "null", "None", None, 4]
+    ) == ["Actions", "4"]
+    assert ai_results_store._clean_category_value(None) is None
+    assert ai_results_store._clean_category_value(" null ") is None
+    assert ai_results_store._clean_category_value(" Actions ") == "Actions"
+    assert ai_results_store._clean_category_value(7) == "7"
+
+
+def test_model_identifier_lookup_and_float_extraction():
+    assert ai_results_store._model_identifier({"identifier": "4", "name": "One"}) == (
+        4,
+        "One",
+    )
+    assert ai_results_store._model_identifier({"model_id": 5}) == (5, None)
+    assert ai_results_store._model_identifier({"external_id": "bad"}) == (None, None)
+    assert ai_results_store._model_lookup_key(1, "Name") == (1, "Name")
+    assert ai_results_store._extract_float(None, "value") is None
+    assert ai_results_store._extract_float({}, "value") is None
+    assert ai_results_store._extract_float({"value": "2.5"}, "value") == 2.5
+    assert ai_results_store._extract_float({"value": "bad"}, "value") is None
+
+
+def test_extract_frame_interval_prefers_metadata_then_inputs():
+    assert ai_results_store._extract_frame_interval_from_run_instance(None) is None
+    run = SimpleNamespace(
+        result_metadata={"frame_interval": "1.5"},
+        input_params={"frame_interval": 2},
+    )
+    assert ai_results_store._extract_frame_interval_from_run_instance(run) == 1.5
+    run.result_metadata = {}
+    assert ai_results_store._extract_frame_interval_from_run_instance(run) == 2
+
+
+def _scene_payload(*, version=1.0, categories=None):
+    return {
+        "schema_version": 3,
+        "duration": 20,
+        "frame_interval": 2,
+        "models": [
+            {
+                "identifier": "7",
+                "name": "Detector",
+                "version": version,
+                "type": "tagger",
+                "categories": categories or ["Actions", "null", ""],
+                "input_params": {"threshold": "0.7", "null_value": "null"},
+                "vendor": "local",
+            },
+            {
+                "external_id": None,
+                "name": "Nameless ID",
+                "version": "invalid",
+                "categories": "invalid",
+            },
+        ],
+        "timespans": {
+            " Actions ": {
+                "Tag A": [
+                    {"start": 0, "end": 3, "confidence": "0.9", "note": "null"},
+                    {"start": 4, "confidence": 0.8},
+                    "invalid",
+                ],
+                "Unknown": [{"start": 1, "end": 2}],
+            },
+            "null": {"Tag B": [{"start": 10, "end": 12, "confidence": None}]},
+            "invalid": "not-a-map",
+        },
+    }
+
+
+def test_store_and_read_scene_runs_with_real_sqlite(result_store_db):
+    references = {("Tag A", "Actions"): 101, ("Tag B", None): 102}
+    resolver = lambda label, category: references.get((label, category))
+
+    run_id = ai_results_store.store_scene_run(
+        service="svc",
+        plugin_name="plugin",
+        scene_id="9",
+        input_params={"frame_interval": "3", "threshold": "0.4", "empty": "null"},
+        result_payload=_scene_payload(),
+        resolve_reference=resolver,
+    )
+    second_id = ai_results_store.store_scene_run(
+        service="svc",
+        plugin_name="plugin-new",
+        scene_id=9,
+        input_params={"frame_interval": 4},
+        result_payload=_scene_payload(version=2.0, categories=["Other"]),
+        resolve_reference=resolver,
+    )
+
+    assert second_id > run_id
+    timespans = ai_results_store.get_scene_timespans(service="svc", scene_id=9)
+    assert timespans == {
+        None: {
+            "102": [
+                {"start": 10.0, "end": 14.0, "confidence": None},
+                {"start": 10.0, "end": 14.0, "confidence": None},
+            ]
+        },
+        "Actions": {
+            "101": [
+                {"start": 0.0, "end": 5.0, "confidence": 0.9},
+                {"start": 0.0, "end": 5.0, "confidence": 0.9},
+                {"start": 4.0, "end": 6.0, "confidence": 0.8},
+                {"start": 4.0, "end": 6.0, "confidence": 0.8},
+            ]
+        },
+    }
+    assert ai_results_store.get_scene_tag_totals(service="svc", scene_id=9) == {
+        101: 14.0,
+        102: 8.0,
+    }
+
+    latest = ai_results_store.get_latest_scene_run(service="svc", scene_id=9)
+    assert latest is not None
+    assert latest.run_id == second_id
+    assert latest.input_params == {"frame_interval": 4}
+    assert latest.aggregates == {"Actions:101": 7.0, "102": 4.0}
+    assert [model.model_name for model in latest.models] == ["Detector", "Nameless ID"]
+    detector = latest.models[0]
+    assert detector.version == 2.0
+    assert detector.categories == ("Other",)
+    assert detector.frame_interval == 2
+    assert detector.threshold == 0.7
+
+    history = ai_results_store.get_scene_model_history(service="svc", scene_id=9)
+    assert [model.model_name for model in history] == ["Detector", "Nameless ID"]
+
+    with result_store_db() as session:
+        detector_row = session.execute(
+            sa.select(AIModel).where(AIModel.name == "Detector")
+        ).scalar_one()
+        assert detector_row.plugin_name == "plugin-new"
+        assert detector_row.extra == {
+            "input_params": {"threshold": "0.7", "null_value": None},
+            "vendor": "local",
+        }
+
+
+def test_scene_reads_handle_empty_results_invalid_ids_and_missing_value_ids(
+    result_store_db,
+):
+    assert ai_results_store.get_scene_timespans(service="svc", scene_id=1) is None
+    assert ai_results_store.get_scene_tag_totals(service="svc", scene_id=1) == {}
+    assert ai_results_store.get_latest_scene_run(service="svc", scene_id=1) is None
+
+    for function in (
+        ai_results_store.get_scene_timespans,
+        ai_results_store.get_scene_tag_totals,
+        ai_results_store.get_scene_model_history,
+        ai_results_store.get_latest_scene_run,
+    ):
+        with pytest.raises(ValueError):
+            function(service="svc", scene_id="invalid")
+
+    with result_store_db() as session:
+        run = AIModelRun(
+            service="svc",
+            entity_type="scene",
+            entity_id=2,
+            status="completed",
+        )
+        session.add(run)
+        session.flush()
+        session.add_all(
+            [
+                AIResultTimespan(
+                    run=run,
+                    entity_type="scene",
+                    entity_id=2,
+                    payload_type="tag",
+                    category="Cat",
+                    value_id=None,
+                    start_s=0,
+                    end_s=1,
+                ),
+                AIResultAggregate(
+                    run=run,
+                    entity_type="scene",
+                    entity_id=2,
+                    payload_type="tag",
+                    category=None,
+                    str_value="fallback",
+                    value_id=None,
+                    metric="duration_s",
+                    value_float=2,
+                ),
+                AIResultAggregate(
+                    run=run,
+                    entity_type="scene",
+                    entity_id=2,
+                    payload_type="tag",
+                    category="ignored",
+                    value_id=1,
+                    metric="presence",
+                    value_float=1,
+                ),
+            ]
+        )
+        session.commit()
+
+    assert ai_results_store.get_scene_timespans(service="svc", scene_id=2) == {}
+    latest = ai_results_store.get_latest_scene_run(service="svc", scene_id=2)
+    assert latest is not None
+    assert latest.aggregates == {"fallback": 2.0}
+
+
+def test_store_image_runs_replace_categories_and_read_unique_tags(result_store_db):
+    first_id = ai_results_store.store_image_run(
+        service="svc",
+        plugin_name="plugin",
+        image_id="5",
+        tag_records={"Category": [1, 2], "null": [3]},
+        input_params={"threshold": "0.5"},
+        requested_models=[
+            {
+                "model_id": 8,
+                "name": "Image Model",
+                "version": 1,
+                "input_params": {"threshold": 0.8},
+            }
+        ],
+    )
+    second_id = ai_results_store.store_image_run(
+        service="svc",
+        plugin_name="plugin",
+        image_id=5,
+        tag_records={"Category": [2, 4], None: [3]},
+    )
+
+    assert second_id > first_id
+    assert set(
+        ai_results_store.get_image_tag_ids(service="svc", image_id=5)
+    ) == {2, 3, 4}
+    history = ai_results_store.get_image_model_history(service="svc", image_id=5)
+    assert len(history) == 1
+    assert history[0].model_name == "Image Model"
+    assert history[0].threshold == 0.8
+
+    with result_store_db() as session:
+        old_aggregates = session.scalars(
+            sa.select(AIResultAggregate).where(AIResultAggregate.run_id == first_id)
+        ).all()
+        assert old_aggregates == []
+
+
+def test_store_image_and_read_helpers_validate_ids_and_empty_payload(result_store_db):
+    with pytest.raises(ValueError):
+        ai_results_store.store_image_run(
+            service="svc",
+            plugin_name=None,
+            image_id="bad",
+            tag_records={},
+        )
+    with pytest.raises(ValueError):
+        ai_results_store.get_image_tag_ids(service="svc", image_id="bad")
+    with pytest.raises(ValueError):
+        ai_results_store.get_image_model_history(service="svc", image_id="bad")
+
+    run_id = ai_results_store.store_image_run(
+        service="svc",
+        plugin_name=None,
+        image_id=7,
+        tag_records=None,
+    )
+    assert run_id > 0
+    assert ai_results_store.get_image_tag_ids(service="svc", image_id=7) == []
+    assert ai_results_store.get_image_model_history(service="svc", image_id=7) == ()
+
+
+def test_purge_scene_categories_respects_empty_values_and_excluded_run(
+    result_store_db,
+):
+    resolver = lambda label, category: 1
+    first = ai_results_store.store_scene_run(
+        service="svc",
+        plugin_name=None,
+        scene_id=3,
+        input_params=None,
+        result_payload={
+            "timespans": {"A": {"Tag": [{"start": 0, "end": 1}]}},
+        },
+        resolve_reference=resolver,
+    )
+    second = ai_results_store.store_scene_run(
+        service="svc",
+        plugin_name=None,
+        scene_id=3,
+        input_params=None,
+        result_payload={
+            "timespans": {"A": {"Tag": [{"start": 2, "end": 3}]}},
+        },
+        resolve_reference=resolver,
+    )
+
+    ai_results_store.purge_scene_categories(
+        service="svc", scene_id=3, categories=[]
+    )
+    ai_results_store.purge_scene_categories(
+        service="svc", scene_id=3, categories=["", ""]
+    )
+    ai_results_store.purge_scene_categories(
+        service="svc",
+        scene_id=3,
+        categories=["A"],
+        exclude_run_id=second,
+    )
+
+    with result_store_db() as session:
+        assert session.scalar(
+            sa.select(sa.func.count()).select_from(AIResultTimespan).where(
+                AIResultTimespan.run_id == first
+            )
+        ) == 0
+        assert session.scalar(
+            sa.select(sa.func.count()).select_from(AIResultTimespan).where(
+                AIResultTimespan.run_id == second
+            )
+        ) == 1
+
+    with pytest.raises(ValueError):
+        ai_results_store.purge_scene_categories(
+            service="svc", scene_id="bad", categories=["A"]
+        )
+
+
+def test_store_timespans_skips_invalid_shapes_and_unresolved_aggregates():
+    added = []
+    session = SimpleNamespace(add=added.append)
+    run = AIModelRun(
+        id=1,
+        service="svc",
+        entity_type="scene",
+        entity_id=1,
+        status="completed",
+    )
+    totals = ai_results_store._store_scene_timespans(
+        session,
+        run=run,
+        scene_id=1,
+        result={
+            "timespans": {
+                "Category": {
+                    "Tag": [None, {"start": 1, "end": 0, "value": "null"}],
+                    "Bad": object(),
+                },
+                "Bad Category": [],
+            }
+        },
+        frame_interval=None,
+        resolve_reference=lambda label, category: None,
+    )
+    assert totals == {("Category", "Tag"): 1.0}
+    assert len(added) == 1
+    assert added[0].value_json == {"value": None}
+
+    ai_results_store._store_aggregates(
+        session,
+        run=run,
+        scene_id=1,
+        totals={("Category", "Unresolved"): 1, ("Category", "Resolved"): 2},
+        resolve_reference=lambda label, category: 5 if label == "Resolved" else None,
+    )
+    assert len(added) == 2
+    assert added[-1].value_id == 5
+
+
+@pytest.mark.asyncio
+async def test_async_wrappers_delegate_to_synchronous_operations(
+    monkeypatch,
+):
+    calls = []
+
+    monkeypatch.setattr(
+        ai_results_store,
+        "get_scene_timespans",
+        lambda **kwargs: calls.append(("timespans", kwargs)) or {"category": {}},
+    )
+    monkeypatch.setattr(
+        ai_results_store,
+        "get_scene_tag_totals",
+        lambda **kwargs: calls.append(("totals", kwargs)) or {1: 2.0},
+    )
+    monkeypatch.setattr(
+        ai_results_store,
+        "store_scene_run",
+        lambda **kwargs: calls.append(("store_scene", kwargs)) or 10,
+    )
+    monkeypatch.setattr(
+        ai_results_store,
+        "store_image_run",
+        lambda **kwargs: calls.append(("store_image", kwargs)) or 11,
+    )
+    monkeypatch.setattr(
+        ai_results_store,
+        "get_image_tag_ids",
+        lambda **kwargs: calls.append(("image_tags", kwargs)) or [1],
+    )
+    monkeypatch.setattr(
+        ai_results_store,
+        "get_latest_scene_run",
+        lambda **kwargs: calls.append(("latest", kwargs)) or None,
+    )
+    monkeypatch.setattr(
+        ai_results_store,
+        "get_scene_model_history",
+        lambda **kwargs: calls.append(("scene_history", kwargs)) or (),
+    )
+    monkeypatch.setattr(
+        ai_results_store,
+        "get_image_model_history",
+        lambda **kwargs: calls.append(("image_history", kwargs)) or (),
+    )
+
+    assert await ai_results_store.get_scene_timespans_async(
+        service="svc", scene_id=1
+    ) == {"category": {}}
+    assert await ai_results_store.get_scene_tag_totals_async(
+        service="svc", scene_id=1
+    ) == {1: 2.0}
+    assert await ai_results_store.store_scene_run_async(
+        service="svc",
+        plugin_name=None,
+        scene_id=1,
+        input_params=None,
+        result_payload={},
+    ) == 10
+    assert await ai_results_store.store_image_run_async(
+        service="svc",
+        plugin_name=None,
+        image_id=1,
+        tag_records={},
+    ) == 11
+    assert await ai_results_store.get_image_tag_ids_async(
+        service="svc", image_id=1
+    ) == [1]
+    assert await ai_results_store.get_latest_scene_run_async(
+        service="svc", scene_id=1
+    ) is None
+    assert await ai_results_store.get_scene_model_history_async(
+        service="svc", scene_id=1
+    ) == ()
+    assert await ai_results_store.get_image_model_history_async(
+        service="svc", image_id=1
+    ) == ()
+    assert len(calls) == 8

--- a/backend/tests/test_api_key_unit.py
+++ b/backend/tests/test_api_key_unit.py
@@ -1,0 +1,138 @@
+"""Unit tests for HTTP and WebSocket shared API key enforcement."""
+
+import pytest
+from fastapi import HTTPException, WebSocketDisconnect
+from starlette.requests import Request
+
+from stash_ai_server.core import api_key
+
+
+def _request(*, header: str | None = None, query: str = "") -> Request:
+    headers = []
+    if header is not None:
+        headers.append((api_key.HEADER_NAME.encode(), header.encode()))
+    return Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": "/",
+            "headers": headers,
+            "query_string": query.encode(),
+        }
+    )
+
+
+class FakeWebSocket:
+    def __init__(self, *, header: str | None = None, query: str | None = None):
+        self.headers = {}
+        if header is not None:
+            self.headers[api_key.HEADER_NAME] = header
+        self.query_params = {}
+        if query is not None:
+            self.query_params[api_key.QUERY_PARAM] = query
+        self.closed = []
+
+    async def close(self, *, code: int, reason: str):
+        self.closed.append((code, reason))
+
+
+@pytest.mark.parametrize(
+    ("stored", "expected"),
+    [
+        (None, None),
+        ("", None),
+        ("  ", None),
+        (" secret ", "secret"),
+        (123, "123"),
+    ],
+)
+def test_get_configured_key_normalizes_values(monkeypatch, stored, expected):
+    monkeypatch.setattr(api_key, "sys_get", lambda _key: stored)
+    assert api_key._get_configured_key() == expected
+
+
+def test_extract_candidate_prefers_header_and_strips_values():
+    assert api_key._extract_candidate(" header ", "query") == "header"
+    assert api_key._extract_candidate("", " query ") == "query"
+    assert api_key._extract_candidate(None, "  ") is None
+    assert api_key._extract_candidate(None, None) is None
+
+
+def test_matches_falls_back_when_compare_digest_rejects_non_ascii_strings():
+    assert api_key._matches("é", "é") is True
+    assert api_key._matches("é", "è") is False
+
+
+@pytest.mark.asyncio
+async def test_http_authentication_is_disabled_without_a_configured_key(monkeypatch):
+    monkeypatch.setattr(api_key, "sys_get", lambda _key: " ")
+    await api_key.require_shared_api_key(_request())
+
+
+@pytest.mark.asyncio
+async def test_http_authentication_accepts_header_or_query_key(monkeypatch):
+    monkeypatch.setattr(api_key, "sys_get", lambda _key: "secret")
+
+    await api_key.require_shared_api_key(_request(header="secret"))
+    await api_key.require_shared_api_key(_request(query="api_key=secret"))
+
+
+@pytest.mark.asyncio
+async def test_http_authentication_rejects_missing_and_invalid_keys(monkeypatch):
+    monkeypatch.setattr(api_key, "sys_get", lambda _key: "secret")
+
+    with pytest.raises(HTTPException) as missing:
+        await api_key.require_shared_api_key(_request())
+    assert missing.value.status_code == 401
+    assert missing.value.detail == "Shared API key required"
+
+    with pytest.raises(HTTPException) as invalid:
+        await api_key.require_shared_api_key(_request(header="wrong"))
+    assert invalid.value.status_code == 403
+    assert invalid.value.detail == "Invalid shared API key"
+
+
+@pytest.mark.asyncio
+async def test_websocket_authentication_is_disabled_or_accepts_valid_key(monkeypatch):
+    socket = FakeWebSocket()
+    monkeypatch.setattr(api_key, "sys_get", lambda _key: None)
+    await api_key.enforce_shared_key_websocket(socket)
+
+    valid_socket = FakeWebSocket(query="secret")
+    monkeypatch.setattr(api_key, "sys_get", lambda _key: "secret")
+    await api_key.enforce_shared_key_websocket(valid_socket)
+
+    assert socket.closed == []
+    assert valid_socket.closed == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("socket_kwargs", "expected_code", "expected_reason"),
+    [
+        (
+            {},
+            api_key.WS_CLOSE_UNAUTHORIZED,
+            "Shared API key required",
+        ),
+        (
+            {"header": "wrong"},
+            api_key.WS_CLOSE_FORBIDDEN,
+            "Invalid shared API key",
+        ),
+    ],
+)
+async def test_websocket_authentication_closes_unauthorized_clients(
+    monkeypatch,
+    socket_kwargs,
+    expected_code,
+    expected_reason,
+):
+    monkeypatch.setattr(api_key, "sys_get", lambda _key: "secret")
+    socket = FakeWebSocket(**socket_kwargs)
+
+    with pytest.raises(WebSocketDisconnect) as raised:
+        await api_key.enforce_shared_key_websocket(socket)
+
+    assert raised.value.code == expected_code
+    assert socket.closed == [(expected_code, expected_reason)]

--- a/backend/tests/test_core_compat.py
+++ b/backend/tests/test_core_compat.py
@@ -1,0 +1,52 @@
+"""Unit tests for backend and frontend version compatibility helpers."""
+
+import pytest
+
+from stash_ai_server.core.compat import is_dev_version, version_satisfies
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (None, False),
+        ("", False),
+        ("   ", False),
+        ("1.2.3", False),
+        ("0.0.0", True),
+        ("0.0.0+local", True),
+        ("1.2.3-dev", True),
+        ("1.2.3-SNAPSHOT", True),
+        ("dirty-build", True),
+    ],
+)
+def test_is_dev_version(value, expected):
+    assert is_dev_version(value) is expected
+
+
+@pytest.mark.parametrize(
+    ("actual", "requirement", "expected"),
+    [
+        ("1.2.3", None, True),
+        ("1.2.3", "", True),
+        (None, ">=1.0.0", False),
+        ("0.0.0+local", ">=999.0.0", True),
+        ("1.2.3", "1.2.3", True),
+        ("1.2.3", "=1.2.3", True),
+        ("1.2.3", "==1.2.3", True),
+        ("1.2.3", "1.2.4", False),
+        ("1.2.3", ">=1.0.0, <2.0.0", True),
+        ("1.2.3", ">=1.2.3 <=1.2.3", True),
+        ("1.2.3", ">1.2.3", False),
+        ("1.2.3", "<1.2.3", False),
+        ("1.2.3", ">1.2.2", True),
+        ("1.2.3", "<1.2.4", True),
+        ("2.0.0", ">=1.0.0 <2.0.0", False),
+        ("1.0.0rc1", "<1.0.0", True),
+        ("not-a-version", ">=1.0.0", False),
+        ("1.2.3", ">=not-a-version", False),
+        ("1.2.3", ">=", True),
+        ("1.2.3", " ,  ", True),
+    ],
+)
+def test_version_satisfies(actual, requirement, expected):
+    assert version_satisfies(actual, requirement) is expected

--- a/backend/tests/test_interactions_service_unit.py
+++ b/backend/tests/test_interactions_service_unit.py
@@ -1,0 +1,602 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.orm import sessionmaker
+
+from stash_ai_server.models.interaction import ImageDerived
+from stash_ai_server.models.interaction import InteractionEvent
+from stash_ai_server.models.interaction import InteractionLibrarySearch
+from stash_ai_server.models.interaction import InteractionSession
+from stash_ai_server.models.interaction import InteractionSessionAlias
+from stash_ai_server.models.interaction import SceneDerived
+from stash_ai_server.models.interaction import SceneWatch
+from stash_ai_server.models.interaction import SceneWatchSegment
+from stash_ai_server.schemas.interaction import InteractionEventIn
+from stash_ai_server.services import interactions
+
+
+@pytest.fixture
+def interaction_db(tmp_path, monkeypatch):
+    engine = sa.create_engine(f"sqlite+pysqlite:///{tmp_path / 'interactions.sqlite'}")
+    for table in (
+        InteractionSession.__table__,
+        InteractionSessionAlias.__table__,
+        InteractionEvent.__table__,
+        SceneWatch.__table__,
+        SceneWatchSegment.__table__,
+        SceneDerived.__table__,
+        ImageDerived.__table__,
+        InteractionLibrarySearch.__table__,
+    ):
+        table.create(engine)
+    factory = sessionmaker(bind=engine, expire_on_commit=False)
+    values = {
+        "INTERACTION_MERGE_TTL_SECONDS": 120,
+        "INTERACTION_MIN_SESSION_MINUTES": 0,
+        "INTERACTION_SEGMENT_TIME_MARGIN_SECONDS": 0.1,
+        "INTERACTION_SEGMENT_POS_MARGIN_SECONDS": 0.5,
+        "SEGMENT_MERGE_GAP_SECONDS": 1,
+        "SEGMENT_MIN_DURATION_SECONDS": 0.1,
+    }
+    monkeypatch.setattr(
+        interactions, "sys_get", lambda key, default=None: values.get(key, default)
+    )
+    try:
+        yield factory
+    finally:
+        engine.dispose()
+
+
+def event(
+    event_id,
+    *,
+    session_id="session",
+    seconds=0,
+    event_type="scene_view",
+    entity_type="scene",
+    entity_id=1,
+    metadata=None,
+):
+    return InteractionEventIn(
+        id=event_id,
+        session_id=session_id,
+        ts=datetime(2024, 1, 1, 12, tzinfo=timezone.utc)
+        + timedelta(seconds=seconds),
+        type=event_type,
+        entity_type=entity_type,
+        entity_id=entity_id,
+        metadata=metadata,
+    )
+
+
+def test_datetime_entity_and_synthetic_event_helpers():
+    naive = datetime(2024, 1, 1, 12)
+    aware = naive.replace(tzinfo=timezone(timedelta(hours=-5)))
+    assert interactions._to_naive(None) is None
+    assert interactions._to_naive(naive) is naive
+    assert interactions._to_naive(aware) == datetime(2024, 1, 1, 17)
+
+    assert interactions._sanitize_entity_id("4") == 4
+    assert interactions._sanitize_entity_id("bad") == 0
+    assert interactions._sanitize_entity_id(interactions.PG_INT_MAX + 1) == 0
+    assert interactions._sanitize_entity_id(-interactions.PG_INT_MAX - 1) == 0
+
+    synthetic = interactions._SyntheticInteractionEvent(
+        client_event_id="event",
+        session_id="session",
+        event_type="scene_watch_progress",
+        entity_type="scene",
+        entity_id=1,
+        client_ts=naive,
+        event_metadata={"position": 2},
+    )
+    assert synthetic.id is None
+    assert synthetic.event_metadata == {"position": 2}
+
+
+def test_recompute_segments_from_rows_covers_controls_progress_seek_and_filtering():
+    def row(kind, metadata):
+        return SimpleNamespace(event_type=kind, event_metadata=metadata)
+
+    rows = [
+        row("scene_watch_start", {"position": 0}),
+        row("scene_watch_progress", {"position": 4}),
+        row("scene_watch_pause", {"position": 5}),
+        row("scene_seek", {"from": 5, "to": 10}),
+        row("scene_watch_start", {}),
+        row("scene_seek", {"from": 14, "to": 20}),
+        row("scene_watch_progress", {"position": 24}),
+        row("scene_watch_complete", {"position": 25}),
+        row("scene_watch_start", {"position": 30}),
+        row("scene_seek", {"from": "bad", "to": "bad"}),
+        row("scene_watch_start", {"position": 40}),
+        row("scene_watch_progress", {"position": 42}),
+    ]
+
+    segments = interactions.recompute_segments_from_rows(
+        rows,
+        "session",
+        1,
+        7,
+        merge_gap=1,
+        min_duration=3,
+    )
+
+    assert [(segment.start_s, segment.end_s, segment.watched_s) for segment in segments] == [
+        (0.0, 5.0, 5.0),
+        (10.0, 14.0, 4.0),
+        (20.0, 25.0, 5.0),
+    ]
+
+
+def test_recompute_segments_queries_rows_and_uses_config(interaction_db, monkeypatch):
+    with interaction_db() as db:
+        db.add(
+            InteractionSession(
+                session_id="session",
+                last_event_ts=datetime(2024, 1, 1),
+                session_start_ts=datetime(2024, 1, 1),
+            )
+        )
+        db.add_all(
+            [
+                InteractionEvent(
+                    client_event_id="a",
+                    session_id="session",
+                    event_type="scene_watch_start",
+                    entity_type="scene",
+                    entity_id=1,
+                    client_ts=datetime(2024, 1, 1),
+                    event_metadata={"position": 0},
+                ),
+                InteractionEvent(
+                    client_event_id="b",
+                    session_id="session",
+                    event_type="scene_watch_pause",
+                    entity_type="scene",
+                    entity_id=1,
+                    client_ts=datetime(2024, 1, 1, 0, 0, 1),
+                    event_metadata={"position": 4},
+                ),
+            ]
+        )
+        db.commit()
+        assert interactions.recompute_segments(db, "session", 1, 9)[0].watched_s == 4
+
+    monkeypatch.setattr(
+        interactions,
+        "sys_get",
+        lambda key, default=None: "invalid"
+        if key == "SEGMENT_MIN_DURATION_SECONDS"
+        else default,
+    )
+    with interaction_db() as db:
+        assert interactions.recompute_segments(db, "missing", 1, 9) == []
+
+
+def test_update_session_tracks_entities_and_session_metadata(interaction_db):
+    with interaction_db() as db:
+        session = InteractionSession(
+            session_id="session",
+            last_event_ts=datetime(2024, 1, 1),
+            session_start_ts=datetime(2024, 1, 1),
+        )
+        db.add(session)
+        db.commit()
+
+        scene_event = SimpleNamespace(
+            id=1,
+            session_id="session",
+            client_ts=datetime(2024, 1, 2, tzinfo=timezone.utc),
+            entity_type="scene",
+            entity_id=4,
+            event_metadata={},
+        )
+        interactions._update_session(db, scene_event)
+        assert session.last_entity_type == "scene"
+        assert session.last_entity_id == 4
+
+        session_event = SimpleNamespace(
+            id=2,
+            session_id="session",
+            client_ts=datetime(2024, 1, 3),
+            entity_type="session",
+            entity_id=0,
+            event_metadata={
+                "last_entity": {
+                    "type": "image",
+                    "id": 8,
+                    "ts": "1704240000000",
+                }
+            },
+        )
+        interactions._update_session(db, session_event, session)
+        assert session.last_entity_type == "image"
+        assert session.last_entity_id == 8
+        assert session.last_entity_event_ts == datetime.utcfromtimestamp(1704240000)
+
+        missing = SimpleNamespace(
+            id=3,
+            session_id="missing",
+            client_ts=datetime(2024, 1, 3),
+            entity_type="scene",
+            entity_id=1,
+            event_metadata={},
+        )
+        with pytest.raises(ValueError):
+            interactions._update_session(db, missing)
+
+
+def test_find_or_create_session_supports_direct_alias_fingerprint_and_new_paths(
+    interaction_db,
+):
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    with interaction_db() as db:
+        db.add_all(
+            [
+                InteractionSession(
+                    session_id="direct",
+                    last_event_ts=now,
+                    session_start_ts=now,
+                ),
+                InteractionSession(
+                    session_id="canonical",
+                    last_event_ts=now,
+                    session_start_ts=now,
+                    client_fingerprint="fingerprint",
+                ),
+                InteractionSessionAlias(
+                    alias_session_id="alias", canonical_session_id="canonical"
+                ),
+            ]
+        )
+        db.commit()
+
+        assert interactions._find_or_create_session_id(db, "direct", None) == "direct"
+        assert interactions._find_or_create_session_id(db, "alias", None) == "canonical"
+        assert (
+            interactions._find_or_create_session_id(
+                db, "fingerprint-alias", "fingerprint"
+            )
+            == "canonical"
+        )
+        assert (
+            db.get(InteractionSessionAlias, "fingerprint-alias").canonical_session_id
+            == "canonical"
+        )
+        assert interactions._find_or_create_session_id(db, "new", None) == "new"
+        assert db.scalar(
+            sa.select(sa.func.count()).select_from(InteractionSession).where(
+                InteractionSession.session_id == "new"
+            )
+        ) == 1
+
+
+def test_finalize_stale_sessions_updates_existing_and_new_derived_rows(interaction_db):
+    old = datetime(2024, 1, 1)
+    with interaction_db() as db:
+        db.add_all(
+            [
+                InteractionSession(
+                    session_id="scene-session",
+                    last_event_ts=old + timedelta(minutes=20),
+                    session_start_ts=old,
+                    client_fingerprint="fp",
+                    last_entity_type="scene",
+                    last_entity_id=1,
+                ),
+                InteractionSession(
+                    session_id="image-session",
+                    last_event_ts=old + timedelta(minutes=15),
+                    session_start_ts=old,
+                    client_fingerprint="fp",
+                    last_entity_type="image",
+                    last_entity_id=2,
+                ),
+                InteractionSession(
+                    session_id="short",
+                    last_event_ts=old,
+                    session_start_ts=old,
+                    client_fingerprint="fp",
+                ),
+                InteractionSession(
+                    session_id="new-scene",
+                    last_event_ts=old + timedelta(minutes=12),
+                    session_start_ts=old,
+                    client_fingerprint="fp",
+                    last_entity_type="scene",
+                    last_entity_id=5,
+                ),
+                InteractionSession(
+                    session_id="new-image",
+                    last_event_ts=old + timedelta(minutes=12),
+                    session_start_ts=old,
+                    client_fingerprint="fp",
+                    last_entity_type="image",
+                    last_entity_id=6,
+                ),
+                SceneDerived(scene_id=1, view_count=2, derived_o_count=3),
+                ImageDerived(image_id=2, view_count=1, derived_o_count=4),
+            ]
+        )
+        db.commit()
+
+        interactions._finalize_stale_sessions_for_fingerprint(
+            db, "fp", datetime(2025, 1, 1)
+        )
+        db.commit()
+
+        assert db.get(SceneDerived, 1).derived_o_count == 4
+        assert db.get(ImageDerived, 2).derived_o_count == 5
+        assert db.get(SceneDerived, 5).derived_o_count == 1
+        assert db.get(SceneDerived, 5).view_count == 1
+        assert db.get(ImageDerived, 6).derived_o_count == 1
+        assert db.get(ImageDerived, 6).view_count == 1
+        assert db.scalar(
+            sa.select(InteractionSession.ended_at).where(
+                InteractionSession.session_id == "scene-session"
+            )
+        ) is not None
+
+
+def test_image_and_scene_derived_helpers_update_existing_and_create_missing(
+    interaction_db,
+):
+    first = datetime(2024, 1, 1)
+    second = datetime(2024, 1, 2)
+    events = [
+        event(
+            "image-1",
+            event_type="image_view",
+            entity_type="image",
+            entity_id=2,
+            seconds=1,
+        ),
+        event(
+            "image-2",
+            event_type="image_view",
+            entity_type="image",
+            entity_id=2,
+            seconds=2,
+        ),
+        event("scene-1", entity_id=3, seconds=1),
+        event("scene-2", entity_id=3, seconds=2),
+    ]
+    events[0].ts = first
+    events[1].ts = second
+    events[2].ts = first
+    events[3].ts = second
+
+    with interaction_db() as db:
+        db.add_all(
+            [
+                ImageDerived(image_id=2, view_count=5, derived_o_count=1),
+                SceneDerived(scene_id=3, view_count=4, derived_o_count=1),
+            ]
+        )
+        db.commit()
+
+        interactions.update_image_derived(db, 2, events)
+        interactions.update_image_derived(db, 9, [])
+        interactions._bulk_update_scene_derived(db, events[2:], {3, 4})
+        interactions._bulk_update_scene_derived(db, [], set())
+        db.commit()
+
+        assert db.get(ImageDerived, 2).view_count == 7
+        assert db.get(ImageDerived, 2).last_viewed_at == second
+        assert db.get(ImageDerived, 9).view_count == 0
+        assert db.get(SceneDerived, 3).view_count == 6
+        assert db.get(SceneDerived, 3).last_viewed_at == second
+        assert db.get(SceneDerived, 4).view_count == 0
+
+
+def test_update_scene_watch_stats_uses_event_duration_then_page_duration(
+    interaction_db,
+):
+    with interaction_db() as db:
+        session = InteractionSession(
+            session_id="session",
+            last_event_ts=datetime(2024, 1, 1),
+            session_start_ts=datetime(2024, 1, 1),
+        )
+        watch = SceneWatch(
+            session_id="session",
+            scene_id=1,
+            page_entered_at=datetime(2024, 1, 1),
+            page_left_at=datetime(2024, 1, 1, 0, 1, 40),
+        )
+        db.add_all([session, watch])
+        db.flush()
+        db.add(
+            InteractionEvent(
+                client_event_id="duration",
+                session_id="session",
+                event_type="scene_watch_pause",
+                entity_type="scene",
+                entity_id=1,
+                client_ts=datetime(2024, 1, 1),
+                event_metadata={"duration": "50"},
+            )
+        )
+        db.commit()
+
+        segments = [
+            SceneWatchSegment(
+                scene_watch_id=watch.id,
+                session_id="session",
+                scene_id=1,
+                start_s=0,
+                end_s=25,
+                watched_s=25,
+            )
+        ]
+        interactions._update_scene_watch_stats(db, watch, segments)
+        assert watch.total_watched_s == 25
+        assert watch.watch_percent == 50
+
+        db.execute(sa.delete(InteractionEvent))
+        db.flush()
+        interactions._update_scene_watch_stats(db, watch, segments)
+        assert watch.watch_percent == 25
+
+
+def test_ingest_events_builds_sessions_watches_segments_and_derived_rows(
+    interaction_db,
+):
+    base = datetime(2024, 1, 1, 12)
+    with interaction_db() as db:
+        db.add(
+            InteractionSession(
+                session_id="session",
+                last_event_ts=base,
+                session_start_ts=base,
+            )
+        )
+        db.commit()
+
+        events = [
+            event("enter", seconds=0, event_type="scene_page_enter"),
+            event("view", seconds=1, event_type="scene_view"),
+            event(
+                "start",
+                seconds=2,
+                event_type="scene_watch_start",
+                metadata={"position": 0, "duration": 40},
+            ),
+            event(
+                "progress",
+                seconds=3,
+                event_type="scene_watch_progress",
+                metadata={"position": 8, "duration": 40},
+            ),
+            event(
+                "pause",
+                seconds=4,
+                event_type="scene_watch_pause",
+                metadata={"position": 10, "duration": 40},
+            ),
+            event(
+                "seek",
+                seconds=5,
+                event_type="scene_seek",
+                metadata={"from": 10, "to": 20},
+            ),
+            event(
+                "start-2",
+                seconds=6,
+                event_type="scene_watch_start",
+                metadata={"position": 20, "duration": 40},
+            ),
+            event(
+                "complete",
+                seconds=7,
+                event_type="scene_watch_complete",
+                metadata={"position": 30, "duration": 40},
+            ),
+            event("leave", seconds=8, event_type="scene_page_leave"),
+            event(
+                "image",
+                seconds=9,
+                event_type="image_view",
+                entity_type="image",
+                entity_id=2,
+            ),
+            event(
+                "search",
+                seconds=10,
+                event_type="library_search",
+                entity_type="library",
+                entity_id=3,
+                metadata={"query": "null", "filters": {"tag": "null"}},
+            ),
+        ]
+
+        accepted, duplicates, errors = interactions.ingest_events(db, events)
+
+        assert accepted == len(events)
+        assert duplicates == 0
+        assert errors == []
+        assert db.scalar(
+            sa.select(sa.func.count()).select_from(InteractionEvent)
+        ) == len(events) - 1
+        watch = db.scalar(sa.select(SceneWatch))
+        assert watch is not None
+        assert watch.page_entered_at == base
+        assert watch.page_left_at == base + timedelta(seconds=8)
+        assert watch.total_watched_s == 20
+        assert watch.watch_percent == 50
+        segments = db.scalars(
+            sa.select(SceneWatchSegment).order_by(SceneWatchSegment.start_s)
+        ).all()
+        assert [(segment.start_s, segment.end_s) for segment in segments] == [
+            (0.0, 10.0),
+            (20.0, 30.0),
+        ]
+        assert db.get(SceneDerived, 1).view_count == 1
+        assert db.get(ImageDerived, 2).view_count == 1
+        search = db.scalar(sa.select(InteractionLibrarySearch))
+        assert search.query is None
+        assert search.filters == {"tag": None}
+
+        duplicate = event(
+            "image",
+            seconds=11,
+            event_type="gallery_view",
+            entity_type="gallery",
+            entity_id=4,
+        )
+        accepted, duplicates, errors = interactions.ingest_events(db, [duplicate])
+        assert (accepted, duplicates, errors) == (0, 1, [])
+
+
+def test_process_helpers_ignore_empty_batches_and_capture_image_errors(monkeypatch):
+    interactions._process_scene_summaries(object(), [], [])
+    errors = []
+    monkeypatch.setattr(
+        interactions,
+        "update_image_derived",
+        lambda *args: (_ for _ in ()).throw(RuntimeError("failed")),
+    )
+    interactions._process_image_derived(
+        object(),
+        [SimpleNamespace(entity_type="image", entity_id=1)],
+        errors,
+    )
+    assert errors == ["image summary 1: failed"]
+
+
+def test_persist_library_search_events_is_best_effort(monkeypatch):
+    added = []
+    fake_db = SimpleNamespace(add=added.append)
+    events = [
+        SimpleNamespace(
+            type="library_search",
+            entity_type="library",
+            entity_id=0,
+            event_metadata={"library": "scenes"},
+            metadata={"query": "term", "filters": {"tag": "null"}},
+            session_id="session",
+        ),
+        SimpleNamespace(
+            type="other",
+            entity_type="other",
+            entity_id=0,
+            metadata={},
+            session_id="session",
+        ),
+    ]
+
+    interactions._persist_library_search_events(fake_db, events)
+
+    assert len(added) == 1
+    assert added[0].library == "scenes"
+    assert added[0].query == "term"
+    assert added[0].filters == {"tag": None}
+
+    monkeypatch.setattr(interactions, "InteractionLibrarySearch", None)
+    interactions._persist_library_search_events(fake_db, events)
+    assert len(added) == 1

--- a/backend/tests/test_plugin_loader_unit.py
+++ b/backend/tests/test_plugin_loader_unit.py
@@ -1,0 +1,677 @@
+from __future__ import annotations
+
+import os
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import sqlalchemy as sa
+from fastapi import APIRouter
+from sqlalchemy.orm import sessionmaker
+
+from stash_ai_server.models.plugin import PluginCatalog
+from stash_ai_server.models.plugin import PluginMeta
+from stash_ai_server.models.plugin import PluginSetting
+from stash_ai_server.models.plugin import PluginSource
+from stash_ai_server.plugin_runtime import loader
+
+
+@pytest.fixture
+def plugin_environment(tmp_path, monkeypatch):
+    plugin_dir = tmp_path / "plugins"
+    plugin_dir.mkdir()
+    engine = sa.create_engine(f"sqlite+pysqlite:///{tmp_path / 'plugins.sqlite'}")
+    for table in (
+        PluginSource.__table__,
+        PluginCatalog.__table__,
+        PluginMeta.__table__,
+        PluginSetting.__table__,
+    ):
+        table.create(engine)
+    factory = sessionmaker(bind=engine, expire_on_commit=False)
+    monkeypatch.setattr(loader, "PLUGIN_DIR", plugin_dir)
+    namespace = sys.modules.get("stash_ai_server.plugins")
+    old_path = list(namespace.__path__) if namespace is not None else None
+    if namespace is not None:
+        namespace.__path__ = [str(plugin_dir)]
+    try:
+        yield plugin_dir, factory
+    finally:
+        if namespace is not None and old_path is not None:
+            namespace.__path__ = old_path
+        engine.dispose()
+
+
+def write_manifest(plugin_dir: Path, name: str, **overrides) -> Path:
+    directory = plugin_dir / name
+    directory.mkdir(parents=True, exist_ok=True)
+    values = {
+        "name": name,
+        "version": "1.0.0",
+        "required_backend": ">=0.9",
+        "files": [],
+        "depends_on": [],
+    }
+    values.update(overrides)
+    import yaml
+
+    path = directory / "plugin.yml"
+    path.write_text(yaml.safe_dump(values))
+    return path
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (None, []),
+        ("plugin", ["plugin"]),
+        ([" one ", "", None, "null", "none", 2], ["one", "2"]),
+        (("a", "b"), ["a", "b"]),
+    ],
+)
+def test_sanitize_dependency_list(raw, expected):
+    assert loader._sanitize_dependency_list(raw) == expected
+
+
+def test_parse_manifest_supports_aliases_coercion_and_rejects_invalid_manifests(
+    plugin_environment,
+):
+    plugin_dir, _ = plugin_environment
+    valid = write_manifest(
+        plugin_dir,
+        "example",
+        version=2,
+        files=["module", 3],
+        depends_on=["dependency", "null"],
+        title="Example Plugin",
+        serverLink="https://example.test",
+        python_dependencies=["package>=1"],
+    )
+    manifest = loader._parse_manifest(valid)
+    assert manifest == loader.PluginManifest(
+        name="example",
+        version="2",
+        required_backend=">=0.9",
+        files=["module", "3"],
+        depends_on=["dependency"],
+        human_name="Example Plugin",
+        server_link="https://example.test",
+        pip_dependencies=["package>=1"],
+    )
+
+    invalid = write_manifest(plugin_dir, "invalid", required_backend=None)
+    assert loader._parse_manifest(invalid) is None
+
+    mismatch = write_manifest(plugin_dir, "mismatch")
+    mismatch.write_text(mismatch.read_text().replace("name: mismatch", "name: other"))
+    assert loader._parse_manifest(mismatch) is None
+
+    non_list_files = write_manifest(plugin_dir, "non_list_files", files="module")
+    assert loader._parse_manifest(non_list_files).files == []
+
+    malformed = plugin_dir / "broken" / "plugin.yml"
+    malformed.parent.mkdir()
+    malformed.write_text("[")
+    assert loader._parse_manifest(malformed) is None
+
+
+def test_catalog_and_settings_helpers_normalize_fallback_fields(monkeypatch):
+    row = SimpleNamespace(
+        dependencies_json={"plugins": ["direct", "null"]},
+        manifest_json={
+            "dependsOn": ["fallback"],
+            "requiredBackend": " >=1 ",
+            "humanName": "Human",
+        },
+        required_backend=None,
+        human_name=None,
+    )
+    assert loader._catalog_dependencies(row) == ["direct"]
+    row.dependencies_json = None
+    assert loader._catalog_dependencies(row) == ["fallback"]
+    assert loader._catalog_required_backend(row) == ">=1"
+    assert loader._catalog_human_name(row) == "Human"
+
+    assert loader._settings_definitions_from_raw(None) == []
+    assert loader._settings_definitions_from_raw(
+        {"settings": {"enabled": {"type": "boolean"}, "limit": 4}}
+    ) == [
+        {"key": "enabled", "type": "boolean"},
+        {"key": "limit", "default": 4},
+    ]
+    assert loader._settings_definitions_from_raw(
+        {"ui_settings": [{"key": "one"}, "invalid"]}
+    ) == [{"key": "one"}]
+
+    captured = []
+    monkeypatch.setattr(
+        loader,
+        "version_satisfies",
+        lambda version, required: captured.append((version, required)) or True,
+    )
+    assert loader._backend_version_ok(">=1") is True
+    assert captured[0][1] == ">=1"
+    assert "requires backend >=1" in loader._format_backend_incompatibility(">=1")
+
+    meta = SimpleNamespace(status=None, last_error=None)
+    loader._mark_incompatible(meta, ">=2")
+    assert meta.status == "incompatible"
+    assert ">=2" in meta.last_error
+
+
+def test_meta_source_and_catalog_creation_are_idempotent(plugin_environment):
+    plugin_dir, factory = plugin_environment
+    manifest = loader.PluginManifest(
+        name="example",
+        version="1",
+        required_backend=">=0",
+        files=[],
+        depends_on=["dependency"],
+        human_name="Example",
+        server_link="https://example.test",
+    )
+    with factory() as db:
+        meta = loader._load_or_create_meta(db, manifest)
+        assert meta.status == "new"
+        assert loader._load_or_create_meta(db, manifest).id == meta.id
+
+        local = loader._ensure_local_source(db)
+        assert loader._ensure_local_source(db).id == local.id
+
+        loader._ensure_catalog_entry_from_manifest(
+            db,
+            manifest=manifest,
+            raw_manifest={"description": "Description", "extra": "null"},
+        )
+        loader._ensure_catalog_entry_from_manifest(
+            db, manifest=manifest, raw_manifest={}
+        )
+        catalog = db.scalar(sa.select(PluginCatalog))
+        assert catalog.dependencies_json == {"plugins": ["dependency"]}
+        assert catalog.manifest_json["extra"] is None
+
+
+def test_load_catalog_row_prefers_requested_source(plugin_environment):
+    _, factory = plugin_environment
+    with factory() as db:
+        first = PluginSource(name="first", url="one", enabled=True)
+        second = PluginSource(name="second", url="two", enabled=True)
+        db.add_all([first, second])
+        db.flush()
+        db.add_all(
+            [
+                PluginCatalog(
+                    source_id=first.id, plugin_name="plugin", version="1"
+                ),
+                PluginCatalog(
+                    source_id=second.id, plugin_name="plugin", version="2"
+                ),
+            ]
+        )
+        db.commit()
+
+        assert (
+            loader._load_catalog_row_for_plugin(
+                db, "plugin", preferred_source_id=second.id
+            ).version
+            == "2"
+        )
+        assert loader._load_catalog_row_for_plugin(db, "missing") is None
+
+
+def test_apply_migrations_runs_pending_files_and_records_failures(
+    plugin_environment, monkeypatch
+):
+    plugin_dir, factory = plugin_environment
+    manifest_path = write_manifest(plugin_dir, "example")
+    manifest = loader._parse_manifest(manifest_path)
+    migrations = manifest_path.parent / "migrations"
+    migrations.mkdir()
+    (migrations / "0001_first.py").write_text(
+        "def upgrade(connection):\n    connection.exec_driver_sql('CREATE TABLE migrated (id INTEGER)')\n"
+    )
+    (migrations / "0002_missing.py").write_text("value = 1\n")
+    probe_session = factory()
+    try:
+        engine = probe_session.get_bind()
+    finally:
+        probe_session.close()
+    monkeypatch.setattr(loader, "get_engine", lambda: engine)
+
+    meta = SimpleNamespace(migration_head=None, status="new", last_error=None)
+    loader._apply_migrations(manifest, meta)
+    assert meta.migration_head == "0001_first"
+    loader._apply_migrations(manifest, meta)
+
+    (migrations / "0003_error.py").write_text(
+        "def upgrade(connection):\n    raise RuntimeError('migration failed')\n"
+    )
+    with pytest.raises(RuntimeError):
+        loader._apply_migrations(manifest, meta)
+    assert meta.status == "error"
+    assert "0003_error.py" in meta.last_error
+
+
+def test_import_files_invokes_register_and_surfaces_failures(monkeypatch, plugin_environment):
+    plugin_dir, _ = plugin_environment
+    monkeypatch.setattr(sys, "path", list(sys.path))
+    manifest = loader.PluginManifest(
+        name="example",
+        version="1",
+        required_backend=">=0",
+        files=["one", "nested/two"],
+        depends_on=[],
+    )
+    calls = []
+    modules = {
+        "stash_ai_server.plugins.example.one": SimpleNamespace(
+            register=lambda: calls.append("one")
+        ),
+        "stash_ai_server.plugins.example.nested.two": SimpleNamespace(
+            register=lambda: calls.append("two")
+        ),
+    }
+    monkeypatch.setattr(
+        loader,
+        "importlib",
+        SimpleNamespace(import_module=modules.__getitem__),
+    )
+    loader._import_files(manifest)
+    assert calls == ["one", "two"]
+
+    modules["stash_ai_server.plugins.example.one"] = SimpleNamespace(
+        register=lambda: (_ for _ in ()).throw(RuntimeError("register failed"))
+    )
+    with pytest.raises(RuntimeError):
+        loader._import_files(manifest)
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="The fake pip executable uses a POSIX shell",
+)
+def test_ensure_pip_dependencies_skips_importable_and_attempts_missing(
+    monkeypatch, tmp_path
+):
+    present = types.ModuleType("present")
+    monkeypatch.setitem(sys.modules, "present", present)
+    marker = tmp_path / "pip-arguments.txt"
+    pip_executable = tmp_path / "pip"
+    pip_executable.write_text(
+        "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$PLUGIN_TEST_MARKER\"\n"
+    )
+    pip_executable.chmod(0o755)
+    monkeypatch.setenv("PATH", str(tmp_path), prepend=os.pathsep)
+    monkeypatch.setenv("PLUGIN_TEST_MARKER", str(marker))
+
+    loader._ensure_pip_dependencies(
+        ["present>=1", "missing-package[extra]==2"]
+    )
+    assert marker.read_text().splitlines() == [
+        "install",
+        "missing-package[extra]==2",
+    ]
+    loader._ensure_pip_dependencies([])
+
+
+def _seed_install_graph(db):
+    source = PluginSource(name="source", url="https://example.test", enabled=True)
+    db.add(source)
+    db.flush()
+    rows = [
+        PluginCatalog(
+            source_id=source.id,
+            plugin_name="dependency",
+            version="1",
+            human_name="Dependency",
+            manifest_json={"required_backend": ">=0"},
+        ),
+        PluginCatalog(
+            source_id=source.id,
+            plugin_name="target",
+            version="2",
+            dependencies_json={"plugins": ["dependency", "missing"]},
+            manifest_json={"required_backend": ">=0"},
+        ),
+    ]
+    db.add_all(rows)
+    db.add(
+        PluginMeta(
+            name="dependency",
+            version="1",
+            required_backend=">=0",
+            status="active",
+        )
+    )
+    db.commit()
+    return source, rows
+
+
+def test_plan_install_resolves_dependencies_active_and_missing(plugin_environment):
+    _, factory = plugin_environment
+    with factory() as db:
+        source, _ = _seed_install_graph(db)
+        plan = loader.plan_install(db, "target", preferred_source_id=source.id)
+        assert plan.order == ["dependency", "target"]
+        assert plan.dependencies == ["dependency"]
+        assert plan.already_active == ["dependency"]
+        assert plan.missing == ["missing"]
+        assert plan.human_names["dependency"] == "Dependency"
+        assert plan.required_backend["target"] == ">=0"
+
+
+def test_execute_install_plan_honors_active_dependencies_and_source_errors(
+    plugin_environment, monkeypatch
+):
+    _, factory = plugin_environment
+    with factory() as db:
+        source, rows = _seed_install_graph(db)
+        plan = loader.InstallPlanResult(
+            plugin="target",
+            order=["dependency", "target"],
+            catalog_rows={row.plugin_name: row for row in rows},
+        )
+        calls = []
+        monkeypatch.setattr(
+            loader,
+            "install_plugin_from_catalog",
+            lambda db, src, row, overwrite=False: calls.append(
+                (row.plugin_name, overwrite)
+            )
+            or PluginMeta(
+                name=row.plugin_name,
+                version=row.version,
+                required_backend=">=0",
+                status="active",
+            ),
+        )
+        assert loader.execute_install_plan(
+            db, plan, overwrite_target=False, install_dependencies=False
+        ) == [("target", "2")]
+        assert calls == [("target", False)]
+
+        missing_source_row = SimpleNamespace(
+            source_id=999,
+            plugin_name="target",
+        )
+        with pytest.raises(RuntimeError):
+            loader.execute_install_plan(
+                db,
+                loader.InstallPlanResult(
+                    plugin="target",
+                    order=["target"],
+                    catalog_rows={"target": missing_source_row},
+                ),
+                overwrite_target=True,
+                install_dependencies=True,
+            )
+
+
+def test_plan_remove_orders_dependents_before_target(plugin_environment):
+    plugin_dir, factory = plugin_environment
+    write_manifest(plugin_dir, "base")
+    write_manifest(plugin_dir, "child", depends_on=["base"])
+    with factory() as db:
+        db.add_all(
+            [
+                PluginMeta(
+                    name="base",
+                    version="1",
+                    required_backend=">=0",
+                    status="active",
+                    human_name="Base",
+                ),
+                PluginMeta(
+                    name="child",
+                    version="1",
+                    required_backend=">=0",
+                    status="active",
+                    human_name="Child",
+                ),
+            ]
+        )
+        db.commit()
+        plan = loader.plan_remove(db, "base")
+        assert plan.order == ["child", "base"]
+        assert plan.dependents == ["child"]
+        assert plan.human_names == {"base": "Base", "child": "Child"}
+        assert loader.plan_remove(db, "missing").order == []
+
+
+def test_initialize_plugins_handles_active_missing_incompatible_cycle_and_error(
+    plugin_environment, monkeypatch
+):
+    plugin_dir, factory = plugin_environment
+    write_manifest(plugin_dir, "dependency", files=["module"])
+    write_manifest(plugin_dir, "active", depends_on=["dependency"], files=["module"])
+    write_manifest(plugin_dir, "missing", depends_on=["absent"])
+    write_manifest(plugin_dir, "incompatible", required_backend=">=99")
+    write_manifest(plugin_dir, "cycle_a", depends_on=["cycle_b"])
+    write_manifest(plugin_dir, "cycle_b", depends_on=["cycle_a"])
+    write_manifest(plugin_dir, "error", files=["module"])
+
+    db = factory()
+    monkeypatch.setattr(loader, "get_session", lambda: db)
+    monkeypatch.setattr(
+        loader,
+        "_backend_version_ok",
+        lambda required: required != ">=99",
+    )
+    monkeypatch.setattr(loader, "_apply_migrations", lambda *args: None)
+    monkeypatch.setattr(loader, "_ensure_pip_dependencies", lambda deps: None)
+    monkeypatch.setattr(loader, "register_settings", lambda *args: None)
+
+    def import_files(manifest):
+        if manifest.name == "error":
+            raise RuntimeError("load failed")
+
+    monkeypatch.setattr(loader, "_import_files", import_files)
+    loader.initialize_plugins()
+
+    with factory() as verify:
+        statuses = {
+            row.name: row.status for row in verify.scalars(sa.select(PluginMeta)).all()
+        }
+        assert statuses["dependency"] == "active"
+        assert statuses["active"] == "active"
+        assert statuses["missing"] == "dependency_missing"
+        assert statuses["incompatible"] == "incompatible"
+        assert statuses["cycle_a"] == "dependency_cycle"
+        assert statuses["cycle_b"] == "dependency_cycle"
+        assert statuses["error"] == "error"
+        assert verify.scalar(
+            sa.select(PluginSource).where(PluginSource.name == "official")
+        ) is not None
+
+
+def test_builtin_source_and_router_registry(plugin_environment):
+    _, factory = plugin_environment
+    with factory() as db:
+        first = loader._ensure_builtin_source(db)
+        second = loader._ensure_builtin_source(db)
+        assert first.id == second.id
+
+    old = loader._plugin_routers.copy()
+    try:
+        loader._plugin_routers.clear()
+        router = APIRouter()
+        loader.register_plugin_router("example", router)
+        returned = loader.get_plugin_routers()
+        assert returned == {"example": router}
+        returned.clear()
+        assert loader.get_plugin_routers() == {"example": router}
+    finally:
+        loader._plugin_routers.clear()
+        loader._plugin_routers.update(old)
+
+
+def test_download_repo_subpath_recurses_and_writes_files(
+    plugin_environment, monkeypatch
+):
+    plugin_dir, _ = plugin_environment
+    responses = {
+        "https://api.github.com/repos/owner/repo/contents/root": SimpleNamespace(
+            status_code=200,
+            raise_for_status=lambda: None,
+            json=lambda: [
+                {
+                    "type": "file",
+                    "name": "one.txt",
+                    "path": "root/one.txt",
+                    "download_url": "https://download/one",
+                },
+                {
+                    "type": "dir",
+                    "name": "nested",
+                    "path": "root/nested",
+                },
+                {"type": "file", "name": "", "path": "ignored"},
+            ],
+        ),
+        "https://api.github.com/repos/owner/repo/contents/root/nested": SimpleNamespace(
+            status_code=200,
+            raise_for_status=lambda: None,
+            json=lambda: {
+                "type": "file",
+                "name": "two.txt",
+                "download_url": "https://download/two",
+            },
+        ),
+        "https://download/one": SimpleNamespace(
+            content=b"one", raise_for_status=lambda: None
+        ),
+        "https://download/two": SimpleNamespace(
+            content=b"two", raise_for_status=lambda: None
+        ),
+    }
+    monkeypatch.setattr(
+        loader,
+        "httpx",
+        SimpleNamespace(get=lambda url, **kwargs: responses[url]),
+    )
+    destination = plugin_dir / "download"
+    assert loader._download_repo_subpath_to_dir(
+        "https://raw.githubusercontent.com/owner/repo/main",
+        "root",
+        destination,
+    )
+    assert (destination / "one.txt").read_bytes() == b"one"
+    assert (destination / "nested" / "two.txt").read_bytes() == b"two"
+
+    with pytest.raises(ValueError):
+        loader._download_repo_subpath_to_dir("https://unsupported.test", "x", destination)
+
+
+def test_install_remove_reload_and_unload_plugin(
+    plugin_environment, monkeypatch
+):
+    plugin_dir, factory = plugin_environment
+    source = SimpleNamespace(url="https://example.test")
+    catalog = SimpleNamespace(
+        plugin_name="example",
+        manifest_json={"path": "example"},
+    )
+
+    def download(_url, _path, destination):
+        write_manifest(
+            destination.parent,
+            destination.name,
+            files=["module"],
+            settings={"enabled": {"type": "boolean"}},
+        )
+
+    monkeypatch.setattr(loader, "_download_repo_subpath_to_dir", download)
+    monkeypatch.setattr(loader, "_backend_version_ok", lambda required: True)
+    monkeypatch.setattr(loader, "_apply_migrations", lambda *args: None)
+    monkeypatch.setattr(loader, "_ensure_pip_dependencies", lambda deps: None)
+    monkeypatch.setattr(loader, "_import_files", lambda manifest: None)
+    settings_calls = []
+    monkeypatch.setattr(
+        loader,
+        "register_settings",
+        lambda db, name, definitions: settings_calls.append((name, definitions)),
+    )
+    monkeypatch.setattr(loader, "_unload_plugin", lambda name: None)
+
+    with factory() as db:
+        meta = loader.install_plugin_from_catalog(db, source, catalog)
+        assert meta.status == "active"
+        assert settings_calls[0][0] == "example"
+        with pytest.raises(FileExistsError):
+            loader.install_plugin_from_catalog(db, source, catalog)
+
+        reloaded = loader.reload_plugin(db, "example")
+        assert reloaded.status == "active"
+
+        db.add(
+            PluginSetting(
+                plugin_name="example",
+                key="enabled",
+                type="boolean",
+            )
+        )
+        db.commit()
+        assert loader.remove_plugin("example", db) is True
+        assert meta.status == "removed"
+        assert not (plugin_dir / "example").exists()
+
+        with pytest.raises(FileNotFoundError):
+            loader.reload_plugin(db, "missing")
+
+
+def test_unload_plugin_unregisters_modules_and_invalidates_caches(monkeypatch):
+    prefix = "stash_ai_server.plugins.example"
+    calls = []
+    module = types.ModuleType(f"{prefix}.module")
+    module.unregister = lambda: calls.append("unregister")
+    monkeypatch.setitem(sys.modules, module.__name__, module)
+    monkeypatch.setattr(
+        loader.services,
+        "unregister_by_plugin",
+        lambda name: calls.append(("service", name)),
+    )
+    monkeypatch.setattr(
+        loader.recommender_registry,
+        "unregister_by_module_prefix",
+        lambda name: calls.append(("recommender", name)),
+    )
+    monkeypatch.setattr(
+        loader,
+        "importlib",
+        SimpleNamespace(invalidate_caches=lambda: calls.append("invalidate")),
+    )
+
+    loader._unload_plugin("example")
+
+    assert module.__name__ not in sys.modules
+    assert "unregister" in calls
+    assert ("service", "example") in calls
+    assert ("recommender", prefix) in calls
+    assert "invalidate" in calls
+
+
+def test_reload_all_and_refresh_are_best_effort(plugin_environment, monkeypatch):
+    plugin_dir, factory = plugin_environment
+    write_manifest(plugin_dir, "one")
+    write_manifest(plugin_dir, "two")
+    db = factory()
+    monkeypatch.setattr(loader, "get_session", lambda: db)
+    calls = []
+    monkeypatch.setattr(loader, "_ensure_builtin_source", lambda db: None)
+    monkeypatch.setattr(loader, "_unload_plugin", lambda name: calls.append(("unload", name)))
+
+    def reload_plugin(db, name):
+        calls.append(("reload", name))
+        if name == "two":
+            raise RuntimeError("failed")
+
+    monkeypatch.setattr(loader, "reload_plugin", reload_plugin)
+    loader.reload_all_plugins()
+    assert ("reload", "one") in calls
+    assert ("reload", "two") in calls
+
+    monkeypatch.setattr(loader, "reload_all_plugins", lambda: calls.append("refresh"))
+    loader._refresh_plugins()
+    assert "refresh" in calls

--- a/backend/tests/test_plugins_api_unit.py
+++ b/backend/tests/test_plugins_api_unit.py
@@ -1,0 +1,755 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import sqlalchemy as sa
+from fastapi import HTTPException
+from sqlalchemy.orm import sessionmaker
+
+from stash_ai_server.api import plugins
+from stash_ai_server.models.plugin import PluginCatalog
+from stash_ai_server.models.plugin import PluginMeta
+from stash_ai_server.models.plugin import PluginSetting
+from stash_ai_server.models.plugin import PluginSource
+
+
+@pytest.fixture
+def plugin_api_db(tmp_path):
+    engine = sa.create_engine(f"sqlite+pysqlite:///{tmp_path / 'plugin-api.sqlite'}")
+    for table in (
+        PluginSource.__table__,
+        PluginCatalog.__table__,
+        PluginMeta.__table__,
+        PluginSetting.__table__,
+    ):
+        table.create(engine)
+    factory = sessionmaker(bind=engine, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        engine.dispose()
+
+
+def make_plan(plugin="target", **overrides):
+    values = {
+        "plugin": plugin,
+        "order": [plugin],
+        "dependencies": [],
+        "already_active": [],
+        "missing": [],
+        "catalog_rows": {plugin: object()},
+        "human_names": {plugin: "Target"},
+        "required_backend": {},
+    }
+    values.update(overrides)
+    return plugins.plugin_loader.InstallPlanResult(**values)
+
+
+def add_source(db, name="source", enabled=True):
+    source = PluginSource(
+        name=name,
+        url=f"https://{name}.example",
+        enabled=enabled,
+    )
+    db.add(source)
+    db.commit()
+    return source
+
+
+def add_meta(db, name="target", status="active", version="1"):
+    meta = PluginMeta(
+        name=name,
+        version=version,
+        required_backend=">=0",
+        status=status,
+    )
+    db.add(meta)
+    db.commit()
+    return meta
+
+
+def test_require_plugin_active_accepts_active_and_reports_other_states(plugin_api_db):
+    with plugin_api_db() as db:
+        active = add_meta(db)
+        assert plugins._require_plugin_active(db, "target") is active
+
+        active.status = "error"
+        active.last_error = "activation failed"
+        db.commit()
+        with pytest.raises(HTTPException) as inactive:
+            plugins._require_plugin_active(db, "target")
+        assert inactive.value.status_code == 409
+        assert inactive.value.detail["status"] == "error"
+        assert inactive.value.detail["message"] == "activation failed"
+
+        with pytest.raises(HTTPException) as missing:
+            plugins._require_plugin_active(db, "missing")
+        assert missing.value.detail["status"] == "missing"
+
+
+def test_require_backend_compatibility_skips_empty_and_rejects_mismatch(monkeypatch):
+    plan = make_plan(
+        order=["dependency", "target"],
+        required_backend={"dependency": None, "target": ">=99"},
+    )
+    monkeypatch.setattr(plugins, "version_satisfies", lambda version, required: False)
+    with pytest.raises(HTTPException) as raised:
+        plugins._require_backend_compatibility(plan)
+    assert raised.value.status_code == 409
+    assert raised.value.detail["code"] == "BACKEND_TOO_OLD"
+    assert raised.value.detail["plugin"] == "target"
+
+    monkeypatch.setattr(plugins, "version_satisfies", lambda version, required: True)
+    plugins._require_backend_compatibility(plan)
+
+
+@pytest.mark.asyncio
+async def test_list_installed_filters_active_and_removed_rows(plugin_api_db):
+    with plugin_api_db() as db:
+        add_meta(db, "active", "active")
+        add_meta(db, "error", "error")
+        add_meta(db, "removed", "removed")
+
+        assert {
+            row.name for row in await plugins.list_installed(db=db)
+        } == {"active", "error"}
+        assert [
+            row.name for row in await plugins.list_installed(active_only=True, db=db)
+        ] == ["active"]
+        assert {
+            row.name
+            for row in await plugins.list_installed(include_removed=True, db=db)
+        } == {"active", "error", "removed"}
+
+
+@pytest.mark.asyncio
+async def test_source_endpoints_are_idempotent_and_protect_local(plugin_api_db):
+    with plugin_api_db() as db:
+        local = add_source(db, "local")
+        remote = add_source(db, "remote")
+        assert [row.name for row in await plugins.list_sources(db)] == ["remote"]
+
+        payload = plugins.PluginSourceCreate(
+            name="remote", url="https://changed.example", enabled=False
+        )
+        assert await plugins.create_source(payload, db) is remote
+        created = await plugins.create_source(
+            plugins.PluginSourceCreate(name="new", url="https://new.example"), db
+        )
+        assert created.id is not None
+
+        with pytest.raises(HTTPException) as missing:
+            await plugins.delete_source("missing", db)
+        assert missing.value.status_code == 404
+        with pytest.raises(HTTPException) as immutable:
+            await plugins.delete_source("local", db)
+        assert immutable.value.detail == "SOURCE_IMMUTABLE"
+        assert await plugins.delete_source("remote", db) == {"status": "deleted"}
+
+
+@pytest.mark.asyncio
+async def test_plugin_setting_list_and_upsert_cover_types_defaults_and_cache(
+    plugin_api_db, monkeypatch
+):
+    invalidations = []
+    monkeypatch.setattr(
+        plugins,
+        "invalidate_path_mapping_cache",
+        lambda plugin_name=None, **kwargs: invalidations.append(
+            (plugin_name, kwargs)
+        ),
+    )
+    with plugin_api_db() as db:
+        db.add_all(
+            [
+                PluginSetting(
+                    plugin_name="plugin",
+                    key="number",
+                    label=None,
+                    type="number",
+                    default_value=3,
+                ),
+                PluginSetting(
+                    plugin_name="plugin",
+                    key="boolean",
+                    type="boolean",
+                    default_value=False,
+                ),
+                PluginSetting(
+                    plugin_name="plugin",
+                    key="select",
+                    type="select",
+                    options=["one", "two"],
+                    default_value="one",
+                ),
+                PluginSetting(
+                    plugin_name="plugin",
+                    key="path_mappings",
+                    type="string",
+                    default_value=[],
+                ),
+            ]
+        )
+        db.commit()
+
+        listed = await plugins.list_plugin_settings("plugin", db)
+        assert listed[0].label == "number"
+        assert listed[0].value == 3
+
+        assert await plugins.upsert_setting(
+            "plugin", "number", plugins.SettingUpsert(value="4.5"), db
+        ) == {"status": "ok"}
+        assert await plugins.upsert_setting(
+            "plugin", "boolean", plugins.SettingUpsert(value="true"), db
+        ) == {"status": "ok"}
+        assert await plugins.upsert_setting(
+            "plugin", "boolean", plugins.SettingUpsert(value=0), db
+        ) == {"status": "ok"}
+        assert await plugins.upsert_setting(
+            "plugin", "select", plugins.SettingUpsert(value="two"), db
+        ) == {"status": "ok"}
+        assert await plugins.upsert_setting(
+            "plugin", "path_mappings", plugins.SettingUpsert(value=[]), db
+        ) == {"status": "ok"}
+        assert invalidations == [("plugin", {})]
+
+        assert await plugins.upsert_setting(
+            "plugin", "new", plugins.SettingUpsert(value="value"), db
+        ) == {"status": "ok"}
+        created = db.scalar(
+            sa.select(PluginSetting).where(
+                PluginSetting.plugin_name == "plugin",
+                PluginSetting.key == "new",
+            )
+        )
+        assert created.label == "new"
+
+        for key, value, detail in (
+            ("number", "bad", "INVALID_NUMBER"),
+            ("boolean", "maybe", "INVALID_BOOLEAN"),
+            ("select", "missing", "INVALID_OPTION"),
+        ):
+            with pytest.raises(HTTPException) as raised:
+                await plugins.upsert_setting(
+                    "plugin", key, plugins.SettingUpsert(value=value), db
+                )
+            assert raised.value.detail == detail
+
+
+@pytest.mark.asyncio
+async def test_system_setting_endpoints_trigger_precise_side_effects(
+    plugin_api_db, monkeypatch
+):
+    cache_calls = []
+    path_calls = []
+    engine_calls = []
+    restart_calls = []
+    monkeypatch.setattr(
+        plugins, "sys_invalidate_cache", lambda: cache_calls.append("cache")
+    )
+    monkeypatch.setattr(
+        plugins,
+        "invalidate_path_mapping_cache",
+        lambda *args, **kwargs: path_calls.append((args, kwargs)),
+    )
+    monkeypatch.setattr(
+        plugins.stash_db,
+        "get_stash_engine",
+        lambda **kwargs: engine_calls.append(kwargs) or object(),
+    )
+    monkeypatch.setattr(
+        plugins, "schedule_backend_restart", lambda: restart_calls.append("restart")
+    )
+
+    with plugin_api_db() as db:
+        db.add_all(
+            [
+                PluginSetting(
+                    plugin_name=plugins.SYSTEM_PLUGIN_NAME,
+                    key="PATH_MAPPINGS",
+                    type="string",
+                    default_value=[],
+                ),
+                PluginSetting(
+                    plugin_name=plugins.SYSTEM_PLUGIN_NAME,
+                    key="STASH_URL",
+                    type="string",
+                    default_value="http://old",
+                ),
+                PluginSetting(
+                    plugin_name=plugins.SYSTEM_PLUGIN_NAME,
+                    key="FLAG",
+                    type="boolean",
+                    default_value=False,
+                ),
+                PluginSetting(
+                    plugin_name=plugins.SYSTEM_PLUGIN_NAME,
+                    key="LIMIT",
+                    type="number",
+                    default_value=1,
+                ),
+                PluginSetting(
+                    plugin_name=plugins.SYSTEM_PLUGIN_NAME,
+                    key="MODE",
+                    type="select",
+                    options=["one", "two"],
+                    default_value="one",
+                ),
+            ]
+        )
+        db.commit()
+
+        listed = await plugins.list_system_settings(db)
+        assert [setting.key for setting in listed] == [
+            "PATH_MAPPINGS",
+            "STASH_URL",
+            "FLAG",
+            "LIMIT",
+            "MODE",
+        ]
+        await plugins.upsert_system_setting(
+            "PATH_MAPPINGS", plugins.SettingUpsert(value=[{"from": "a"}]), db
+        )
+        await plugins.upsert_system_setting(
+            "STASH_URL", plugins.SettingUpsert(value="http://new"), db
+        )
+        await plugins.upsert_system_setting(
+            "FLAG", plugins.SettingUpsert(value=1), db
+        )
+        await plugins.upsert_system_setting(
+            "LIMIT", plugins.SettingUpsert(value="2.5"), db
+        )
+        await plugins.upsert_system_setting(
+            "MODE", plugins.SettingUpsert(value="two"), db
+        )
+
+        assert len(cache_calls) == 5
+        assert path_calls == [((), {"system": True})]
+        assert engine_calls == [{"refresh": True}]
+        assert restart_calls == ["restart"]
+
+        with pytest.raises(HTTPException) as missing:
+            await plugins.upsert_system_setting(
+                "MISSING", plugins.SettingUpsert(value=1), db
+            )
+        assert missing.value.status_code == 404
+
+        for key, value, detail in (
+            ("LIMIT", "bad", "INVALID_NUMBER"),
+            ("FLAG", "bad", "INVALID_BOOLEAN"),
+            ("MODE", "bad", "INVALID_OPTION"),
+        ):
+            with pytest.raises(HTTPException) as raised:
+                await plugins.upsert_system_setting(
+                    key, plugins.SettingUpsert(value=value), db
+                )
+            assert raised.value.detail == detail
+
+
+class Response:
+    def __init__(self, status_code=200, payload=None, json_error=None):
+        self.status_code = status_code
+        self.payload = payload
+        self.json_error = json_error
+
+    def json(self):
+        if self.json_error is not None:
+            raise self.json_error
+        return self.payload
+
+
+@pytest.fixture
+def async_client_double(monkeypatch):
+    state = SimpleNamespace(response=Response(), error=None)
+
+    class Client:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, traceback):
+            return False
+
+        async def get(self, url):
+            if state.error is not None:
+                raise state.error
+            return state.response
+
+    monkeypatch.setattr(
+        plugins,
+        "httpx",
+        SimpleNamespace(AsyncClient=Client),
+    )
+    return state
+
+
+@pytest.mark.asyncio
+async def test_refresh_source_validates_source_state(
+    plugin_api_db, async_client_double
+):
+    with plugin_api_db() as db:
+        with pytest.raises(HTTPException) as missing:
+            await plugins.refresh_source("missing", db)
+        assert missing.value.status_code == 404
+
+        add_source(db, "disabled", enabled=False)
+        with pytest.raises(HTTPException) as disabled:
+            await plugins.refresh_source("disabled", db)
+        assert disabled.value.detail == "SOURCE_DISABLED"
+
+        add_source(db, "local")
+        with pytest.raises(HTTPException) as immutable:
+            await plugins.refresh_source("local", db)
+        assert immutable.value.detail == "SOURCE_IMMUTABLE"
+
+
+@pytest.mark.asyncio
+async def test_refresh_source_imports_catalog_and_normalizes_dependencies(
+    plugin_api_db, async_client_double
+):
+    async_client_double.response = Response(
+        payload={
+            "schemaVersion": 1,
+            "plugins": [
+                {
+                    "name": "one",
+                    "version": "2",
+                    "dependsOn": [" dep ", "null", None],
+                    "humanName": "One",
+                    "serverLink": "https://one.example",
+                    "optional": "null",
+                },
+                {
+                    "plugin_name": "two",
+                    "depends_on": "dep-two",
+                    "description": "Two",
+                },
+                {"version": "missing-name"},
+            ],
+        }
+    )
+    with plugin_api_db() as db:
+        source = add_source(db)
+        db.add(
+            PluginCatalog(
+                source_id=source.id, plugin_name="old", version="1"
+            )
+        )
+        db.commit()
+
+        result = await plugins.refresh_source("source", db)
+
+        assert result.fetched == 2
+        assert result.errors == []
+        rows = db.scalars(
+            sa.select(PluginCatalog).order_by(PluginCatalog.plugin_name)
+        ).all()
+        assert [row.plugin_name for row in rows] == ["one", "two"]
+        assert rows[0].dependencies_json == {"plugins": ["dep"]}
+        assert rows[0].manifest_json["optional"] is None
+        assert rows[1].dependencies_json == {"plugins": ["dep-two"]}
+        assert source.last_error is None
+        assert source.last_refreshed_at is not None
+
+
+@pytest.mark.asyncio
+async def test_refresh_source_reports_http_json_schema_and_transport_errors(
+    plugin_api_db, async_client_double
+):
+    with plugin_api_db() as db:
+        source = add_source(db)
+
+        async_client_double.response = Response(status_code=503)
+        assert (await plugins.refresh_source("source", db)).errors == ["HTTP 503"]
+
+        async_client_double.response = Response(json_error=ValueError("bad json"))
+        assert (
+            await plugins.refresh_source("source", db)
+        ).errors[0].startswith("json_parse_error:")
+
+        async_client_double.response = Response(
+            payload={"schemaVersion": 9, "plugins": []}
+        )
+        assert "schema_version_mismatch" in (
+            await plugins.refresh_source("source", db)
+        ).errors[0]
+
+        async_client_double.error = RuntimeError("network failed")
+        result = await plugins.refresh_source("source", db)
+        assert result.errors == ["exception:network failed"]
+        assert source.last_error == "network failed"
+
+
+@pytest.mark.asyncio
+async def test_catalog_and_install_plan_endpoints(plugin_api_db, monkeypatch):
+    with plugin_api_db() as db:
+        with pytest.raises(HTTPException):
+            await plugins.list_catalog("missing", db)
+        source = add_source(db)
+        db.add(
+            PluginCatalog(
+                source_id=source.id,
+                plugin_name="target",
+                version="2",
+                description="Description",
+                manifest_json={"path": "target"},
+            )
+        )
+        db.commit()
+        assert await plugins.list_catalog("source", db) == [
+            {
+                "plugin_name": "target",
+                "version": "2",
+                "description": "Description",
+                "manifest": {"path": "target"},
+            }
+        ]
+
+        with pytest.raises(HTTPException) as required:
+            await plugins.install_plan({}, db)
+        assert required.value.detail == "PLUGIN_REQUIRED"
+
+        with pytest.raises(HTTPException) as missing_source:
+            await plugins.install_plan(
+                {"plugin": "target", "source": "missing"}, db
+            )
+        assert missing_source.value.detail == "SOURCE_NOT_FOUND"
+
+        plan = make_plan(
+            order=["dependency", "target"],
+            dependencies=["dependency"],
+            already_active=["dependency"],
+            missing=[],
+            human_names={"dependency": "Dependency", "target": "Target"},
+        )
+        monkeypatch.setattr(plugins.plugin_loader, "plan_install", lambda *args, **kwargs: plan)
+        response = await plugins.install_plan(
+            {"plugin": "target", "source": "source"}, db
+        )
+        assert response.install_order == ["dependency", "target"]
+        assert response.already_installed == ["dependency"]
+
+        monkeypatch.setattr(
+            plugins.plugin_loader,
+            "plan_install",
+            lambda *args, **kwargs: make_plan(catalog_rows={}),
+        )
+        with pytest.raises(HTTPException) as missing_plugin:
+            await plugins.install_plan({"plugin": "target"}, db)
+        assert missing_plugin.value.detail == "PLUGIN_NOT_FOUND"
+
+
+@pytest.mark.asyncio
+async def test_install_plugin_validates_dependencies_compatibility_and_execution(
+    plugin_api_db, monkeypatch
+):
+    with plugin_api_db() as db:
+        source = add_source(db)
+        add_meta(db, version="9")
+
+        with pytest.raises(HTTPException) as missing_source:
+            await plugins.install_plugin(
+                {"source": "missing", "plugin": "target"}, db
+            )
+        assert missing_source.value.status_code == 404
+
+        plan = make_plan(missing=["absent"])
+        monkeypatch.setattr(plugins.plugin_loader, "plan_install", lambda *args, **kwargs: plan)
+        with pytest.raises(HTTPException) as missing_dependency:
+            await plugins.install_plugin(
+                {"source": "source", "plugin": "target"}, db
+            )
+        assert missing_dependency.value.detail["code"] == "DEPENDENCY_MISSING"
+
+        plan = make_plan(
+            order=["dependency", "target"],
+            dependencies=["dependency"],
+            human_names={"dependency": "Dependency"},
+        )
+        monkeypatch.setattr(plugins.plugin_loader, "plan_install", lambda *args, **kwargs: plan)
+        monkeypatch.setattr(plugins, "_require_backend_compatibility", lambda plan: None)
+        with pytest.raises(HTTPException) as required:
+            await plugins.install_plugin(
+                {"source": "source", "plugin": "target"}, db
+            )
+        assert required.value.detail["code"] == "DEPENDENCIES_REQUIRED"
+
+        monkeypatch.setattr(
+            plugins.plugin_loader,
+            "execute_install_plan",
+            lambda *args, **kwargs: [("dependency", "1"), ("target", "2")],
+        )
+        result = await plugins.install_plugin(
+            {
+                "source": "source",
+                "plugin": "target",
+                "overwrite": True,
+                "install_dependencies": True,
+            },
+            db,
+        )
+        assert result["status"] == "installed"
+        assert result["version"] == "2"
+
+        monkeypatch.setattr(
+            plugins.plugin_loader,
+            "execute_install_plan",
+            lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("failed")),
+        )
+        with pytest.raises(HTTPException) as failed:
+            await plugins.install_plugin(
+                {
+                    "source": "source",
+                    "plugin": "target",
+                    "install_dependencies": True,
+                },
+                db,
+            )
+        assert failed.value.status_code == 500
+
+
+@pytest.mark.asyncio
+async def test_update_plugin_success_and_failure_paths(plugin_api_db, monkeypatch):
+    with plugin_api_db() as db:
+        add_source(db)
+        add_meta(db, version="9")
+
+        with pytest.raises(HTTPException):
+            await plugins.update_plugin(
+                {"source": "missing", "plugin": "target"}, db
+            )
+
+        monkeypatch.setattr(
+            plugins.plugin_loader,
+            "plan_install",
+            lambda *args, **kwargs: make_plan(catalog_rows={}),
+        )
+        with pytest.raises(HTTPException) as missing:
+            await plugins.update_plugin(
+                {"source": "source", "plugin": "target"}, db
+            )
+        assert missing.value.detail == "PLUGIN_NOT_FOUND"
+
+        monkeypatch.setattr(
+            plugins.plugin_loader,
+            "plan_install",
+            lambda *args, **kwargs: make_plan(missing=["dep"]),
+        )
+        with pytest.raises(HTTPException) as dependency:
+            await plugins.update_plugin(
+                {"source": "source", "plugin": "target"}, db
+            )
+        assert dependency.value.detail["code"] == "DEPENDENCY_MISSING"
+
+        monkeypatch.setattr(
+            plugins.plugin_loader, "plan_install", lambda *args, **kwargs: make_plan()
+        )
+        monkeypatch.setattr(plugins, "_require_backend_compatibility", lambda plan: None)
+        monkeypatch.setattr(
+            plugins.plugin_loader,
+            "execute_install_plan",
+            lambda *args, **kwargs: [("target", "3")],
+        )
+        result = await plugins.update_plugin(
+            {"source": "source", "plugin": "target"}, db
+        )
+        assert result["status"] == "updated"
+        assert result["version"] == "3"
+
+        monkeypatch.setattr(
+            plugins.plugin_loader,
+            "execute_install_plan",
+            lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("failed")),
+        )
+        with pytest.raises(HTTPException) as failed:
+            await plugins.update_plugin(
+                {"source": "source", "plugin": "target"}, db
+            )
+        assert failed.value.status_code == 500
+
+
+@pytest.mark.asyncio
+async def test_remove_plan_reload_and_remove_endpoints(plugin_api_db, monkeypatch):
+    with plugin_api_db() as db:
+        with pytest.raises(HTTPException) as required:
+            await plugins.remove_plan({}, db)
+        assert required.value.detail == "PLUGIN_REQUIRED"
+
+        monkeypatch.setattr(
+            plugins.plugin_loader,
+            "plan_remove",
+            lambda db, name: plugins.plugin_loader.RemovePlanResult(plugin=name),
+        )
+        with pytest.raises(HTTPException) as missing:
+            await plugins.remove_plan({"plugin": "target"}, db)
+        assert missing.value.status_code == 404
+
+        plan = plugins.plugin_loader.RemovePlanResult(
+            plugin="target",
+            order=["dependent", "target"],
+            dependents=["dependent"],
+            human_names={"dependent": "Dependent"},
+        )
+        monkeypatch.setattr(plugins.plugin_loader, "plan_remove", lambda db, name: plan)
+        response = await plugins.remove_plan({"plugin": "target"}, db)
+        assert response.remove_order == ["dependent", "target"]
+
+        with pytest.raises(HTTPException) as dependents:
+            await plugins.remove_plugin_api({"plugin": "target"}, db)
+        assert dependents.value.detail["code"] == "DEPENDENT_PLUGINS"
+
+        removed = []
+        monkeypatch.setattr(
+            plugins.plugin_loader,
+            "remove_plugin",
+            lambda name, db: removed.append(name),
+        )
+        result = await plugins.remove_plugin_api(
+            {"plugin": "target", "cascade": True}, db
+        )
+        assert result["removed"] == ["dependent", "target"]
+        assert removed == ["dependent", "target"]
+
+        monkeypatch.setattr(
+            plugins.plugin_loader,
+            "remove_plugin",
+            lambda name, db: (_ for _ in ()).throw(RuntimeError("failed")),
+        )
+        with pytest.raises(HTTPException) as removal_failed:
+            await plugins.remove_plugin_api(
+                {"plugin": "target", "cascade": True}, db
+            )
+        assert removal_failed.value.status_code == 500
+
+        with pytest.raises(HTTPException) as reload_required:
+            await plugins.reload_plugin_endpoint(plugins.ReloadRequest(plugin=" "), db)
+        assert reload_required.value.detail == "PLUGIN_REQUIRED"
+
+        meta = add_meta(db, "reloaded")
+        monkeypatch.setattr(
+            plugins.plugin_loader, "reload_plugin", lambda db, name: meta
+        )
+        assert (
+            await plugins.reload_plugin_endpoint(
+                plugins.ReloadRequest(plugin=" reloaded "), db
+            )
+        ) is meta
+
+        for error, status in (
+            (FileNotFoundError(), 404),
+            (RuntimeError("incompatible"), 409),
+            (ValueError("unexpected"), 500),
+        ):
+            monkeypatch.setattr(
+                plugins.plugin_loader,
+                "reload_plugin",
+                lambda *args, error=error: (_ for _ in ()).throw(error),
+            )
+            with pytest.raises(HTTPException) as raised:
+                await plugins.reload_plugin_endpoint(
+                    plugins.ReloadRequest(plugin="target"), db
+                )
+            assert raised.value.status_code == status

--- a/backend/tests/test_recommendation_pagination.py
+++ b/backend/tests/test_recommendation_pagination.py
@@ -1,0 +1,96 @@
+"""Unit tests for recommendation pagination and cache helpers."""
+
+from stash_ai_server.recommendations.models import RecContext, RecommendationRequest
+from stash_ai_server.recommendations.utils.pagination import (
+    get_cached_page,
+    paginate_items,
+    resolve_pagination,
+    store_cache,
+)
+
+
+def _request(**overrides) -> RecommendationRequest:
+    values = {
+        "context": RecContext.global_feed,
+        "recommenderId": "example",
+    }
+    values.update(overrides)
+    return RecommendationRequest(**values)
+
+
+def test_resolve_pagination_uses_defaults_and_sanitizes_values():
+    assert resolve_pagination(_request()) == (0, 40)
+    assert resolve_pagination(_request(offset=-5, limit=-2)) == (0, 0)
+    assert resolve_pagination(_request(offset=4, limit=0)) == (4, 0)
+    assert resolve_pagination(_request(offset=4, limit=12)) == (4, 12)
+    assert resolve_pagination(_request(limit=None), default_limit=25) == (0, 25)
+
+
+def test_resolve_pagination_handles_unvalidated_input_types():
+    request = RecommendationRequest.model_construct(
+        context=RecContext.global_feed,
+        recommenderId="example",
+        offset="bad",
+        limit="bad",
+    )
+
+    assert resolve_pagination(request, default_limit=15) == (0, 15)
+
+
+def test_cache_returns_none_for_missing_bucket_or_key():
+    assert get_cached_page(ctx={}, cache_key="key", offset=0, limit=10) is None
+    assert (
+        get_cached_page(
+            ctx={"_precomputed_pages": {"other": {"items": [1]}}},
+            cache_key="key",
+            offset=0,
+            limit=10,
+        )
+        is None
+    )
+
+
+def test_store_and_get_cached_pages():
+    context = {}
+    store_cache(ctx=context, cache_key=("profile", 1), items=(1, 2, 3, 4))
+
+    assert get_cached_page(
+        ctx=context,
+        cache_key=("profile", 1),
+        offset=1,
+        limit=2,
+    ) == ([2, 3], 4, True)
+    assert get_cached_page(
+        ctx=context,
+        cache_key=("profile", 1),
+        offset=4,
+        limit=2,
+    ) == ([], 4, False)
+    assert get_cached_page(
+        ctx=context,
+        cache_key=("profile", 1),
+        offset=2,
+        limit=0,
+    ) == ([3, 4], 4, False)
+
+
+def test_store_cache_overwrites_only_the_selected_key():
+    context = {}
+    store_cache(ctx=context, cache_key="first", items=[1])
+    store_cache(ctx=context, cache_key="second", items=[2])
+    store_cache(ctx=context, cache_key="first", items=[3, 4])
+
+    assert get_cached_page(
+        ctx=context, cache_key="first", offset=0, limit=10
+    ) == ([3, 4], 2, False)
+    assert get_cached_page(
+        ctx=context, cache_key="second", offset=0, limit=10
+    ) == ([2], 1, False)
+
+
+def test_paginate_items_handles_bounds_and_unlimited_pages():
+    items = ["a", "b", "c"]
+
+    assert paginate_items(items, offset=1, limit=1) == (["b"], 3, True)
+    assert paginate_items(items, offset=10, limit=2) == ([], 3, False)
+    assert paginate_items(items, offset=1, limit=0) == (["b", "c"], 3, False)

--- a/backend/tests/test_recommendation_registry_unit.py
+++ b/backend/tests/test_recommendation_registry_unit.py
@@ -1,0 +1,171 @@
+"""Unit tests for recommendation registries and stored preferences."""
+
+from enum import Enum
+
+import pytest
+
+from stash_ai_server.models.recommendation import RecommendationPreference
+from stash_ai_server.recommendations import registry as recommendation_registry
+from stash_ai_server.recommendations import storage
+from stash_ai_server.recommendations.models import RecContext, RecommenderDefinition
+
+
+class FakeResult:
+    def __init__(self, row):
+        self.row = row
+
+    def scalar_one_or_none(self):
+        return self.row
+
+
+class FakeSession:
+    def __init__(self, row=None):
+        self.row = row
+        self.added = []
+        self.commits = 0
+        self.refreshed = []
+
+    def execute(self, _statement):
+        return FakeResult(self.row)
+
+    def add(self, row):
+        self.added.append(row)
+        self.row = row
+
+    def commit(self):
+        self.commits += 1
+
+    def refresh(self, row):
+        self.refreshed.append(row)
+
+
+def _definition(identifier="example", contexts=None):
+    return RecommenderDefinition(
+        id=identifier,
+        label=identifier,
+        contexts=contexts or [RecContext.global_feed],
+    )
+
+
+def test_recommender_registry_registers_lists_gets_and_rejects_duplicates():
+    registry = recommendation_registry._RecommenderRegistry()
+    definition = _definition()
+
+    def handler(*_args):
+        return []
+
+    registry.register(definition, handler)
+
+    assert registry.get("example") == (definition, handler)
+    assert registry.get("missing") is None
+    assert registry.list_for_context(RecContext.global_feed) == [definition]
+    assert registry.list_for_context(RecContext.similar_scene) == []
+    with pytest.raises(ValueError, match="already registered"):
+        registry.register(definition, handler)
+
+
+def test_recommender_registry_unregisters_handlers_by_module_prefix():
+    registry = recommendation_registry._RecommenderRegistry()
+
+    def first(*_args):
+        return []
+
+    def second(*_args):
+        return []
+
+    first.__module__ = "plugins.first.recommender"
+    second.__module__ = "plugins.second.recommender"
+    registry.register(_definition("first"), first)
+    registry.register(_definition("second"), second)
+
+    registry.unregister_by_module_prefix("")
+    registry.unregister_by_module_prefix("plugins.first")
+
+    assert registry.get("first") is None
+    assert registry.get("second") is not None
+
+
+def test_recommender_decorator_registers_definition(monkeypatch):
+    registry = recommendation_registry._RecommenderRegistry()
+    monkeypatch.setattr(
+        recommendation_registry,
+        "recommender_registry",
+        registry,
+    )
+
+    @recommendation_registry.recommender(
+        id="decorated",
+        label="Decorated",
+        contexts=[RecContext.similar_scene],
+        description="Description",
+        config=[],
+        needs_seed_scenes=True,
+    )
+    def handler(*_args):
+        return []
+
+    definition, registered_handler = registry.get("decorated")
+    assert registered_handler is handler
+    assert definition.description == "Description"
+    assert definition.contexts == [RecContext.similar_scene]
+    assert definition.needs_seed_scenes is True
+
+
+def test_context_value_handles_none_enum_and_plain_values():
+    class Context(Enum):
+        feed = "feed"
+
+    assert storage._context_value(None) == ""
+    assert storage._context_value(Context.feed) == "feed"
+    assert storage._context_value(123) == "123"
+
+
+def test_get_preference_skips_empty_context_and_returns_query_result():
+    session = FakeSession()
+    assert storage.get_preference(session, None) is None
+
+    row = RecommendationPreference(
+        context="global_feed",
+        recommender_id="example",
+        config={},
+    )
+    session.row = row
+    assert storage.get_preference(session, RecContext.global_feed) is row
+
+
+def test_save_preference_creates_or_updates_rows():
+    new_session = FakeSession()
+
+    created = storage.save_preference(
+        new_session,
+        RecContext.global_feed,
+        "first",
+        None,
+    )
+
+    assert created.context == "global_feed"
+    assert created.recommender_id == "first"
+    assert created.config == {}
+    assert new_session.added == [created]
+    assert new_session.commits == 1
+    assert new_session.refreshed == [created]
+
+    existing = RecommendationPreference(
+        context="global_feed",
+        recommender_id="old",
+        config={"old": True},
+    )
+    existing_session = FakeSession(existing)
+    updated = storage.save_preference(
+        existing_session,
+        RecContext.global_feed,
+        "new",
+        {"limit": 10},
+    )
+
+    assert updated is existing
+    assert existing.recommender_id == "new"
+    assert existing.config == {"limit": 10}
+    assert existing_session.added == []
+    assert existing_session.commits == 1
+    assert existing_session.refreshed == [existing]

--- a/backend/tests/test_recommendation_utils_unit.py
+++ b/backend/tests/test_recommendation_utils_unit.py
@@ -1,0 +1,749 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.orm import sessionmaker
+
+from stash_ai_server.recommendations.utils import scene_fetch
+from stash_ai_server.recommendations.utils import tag_profiles
+from stash_ai_server.recommendations.utils import timespan_metrics
+from stash_ai_server.recommendations.utils import watch_history
+
+
+class FakeSession:
+    def __init__(self, rows=(), scalar=None, error: Exception | None = None):
+        self.rows = rows
+        self.scalar = scalar
+        self.error = error
+        self.statements = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, traceback):
+        return False
+
+    def execute(self, statement):
+        self.statements.append(statement)
+        if self.error is not None:
+            raise self.error
+        return FakeResult(self.rows, self.scalar)
+
+
+class FakeResult(list):
+    def __init__(self, rows=(), scalar=None):
+        super().__init__(rows)
+        self._scalar = scalar
+
+    def scalar_one_or_none(self):
+        return self._scalar
+
+
+def install_session(monkeypatch, module, *, rows=(), scalar=None, error=None):
+    sessions = []
+
+    def factory():
+        session = FakeSession(rows=rows, scalar=scalar, error=error)
+        sessions.append(session)
+        return session
+
+    monkeypatch.setattr(module, "get_session_local", lambda: factory)
+    return sessions
+
+
+def test_scene_payload_helpers_fill_defaults_without_overwriting_values():
+    stub = scene_fetch._stub_scene("7")
+    assert stub["id"] == 7
+    assert stub["title"] == "Scene 7"
+
+    payload = {"paths": {"preview": "preview"}, "performers": [{"id": 1}]}
+    normalized = scene_fetch._normalize_scene_payload(payload)
+    assert normalized["paths"] == {
+        "preview": "preview",
+        "screenshot": None,
+        "stream": None,
+        "webp": None,
+    }
+    assert normalized["performers"] == [{"id": 1}]
+    assert normalized["tags"] == []
+    assert normalized["files"] == []
+    assert normalized["series"] == []
+
+
+def test_scene_column_helpers_support_missing_and_alternative_columns():
+    metadata = sa.MetaData()
+    table = sa.Table(
+        "items",
+        metadata,
+        sa.Column("identifier", sa.Integer),
+        sa.Column("title", sa.String),
+    )
+
+    assert scene_fetch._pick_column(table, "missing", "identifier") is table.c.identifier
+    assert scene_fetch._pick_column(None, "identifier") is None
+    assert scene_fetch._pick_column(table, "missing") is None
+    assert scene_fetch._column_with_default(table, "title").name == "title"
+    assert scene_fetch._column_with_default(table, "missing", alias="fallback").name == "fallback"
+    assert scene_fetch._label_or_literal(table.c.identifier, "id").name == "id"
+    assert scene_fetch._label_or_literal(None, "empty").name == "empty"
+
+    class BrokenColumn:
+        def label(self, _alias):
+            raise RuntimeError("cannot label")
+
+    assert scene_fetch._label_or_literal(BrokenColumn(), "safe").name == "safe"
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (None, None),
+        ("", None),
+        ("  ", None),
+        (12, 12),
+        (12.9, 12),
+        ("123", 123),
+        ("2024-01-02T03:04:05Z", 1704164645),
+        ("2024-01-02T03:04:05", 1704164645),
+        ("invalid", None),
+        (object(), None),
+    ],
+)
+def test_coerce_unix_timestamp(raw, expected):
+    assert scene_fetch._coerce_unix_timestamp(raw) == expected
+
+
+def test_scene_urls_include_filtered_params_and_api_key(monkeypatch):
+    monkeypatch.setattr(
+        scene_fetch,
+        "stash_api",
+        SimpleNamespace(api_key="shared key"),
+    )
+
+    assert scene_fetch._build_scene_url(4, "preview") == "/scene/4/preview"
+    assert scene_fetch._build_scene_url(
+        4,
+        "stream",
+        include_api_key=True,
+        params={"empty": "", "quality": "720p"},
+    ) == "/scene/4/stream?quality=720p&apikey=shared+key"
+    assert scene_fetch._build_scene_paths(4) == {
+        "screenshot": "/scene/4/screenshot",
+        "preview": "/scene/4/preview",
+        "stream": "/scene/4/stream?apikey=shared+key",
+        "webp": "/scene/4/webp",
+    }
+    assert scene_fetch._build_performer_image_url(
+        9, updated_at="2024-01-02T03:04:05Z"
+    ) == "/performer/9/image?default=true&t=1704164645"
+    assert scene_fetch._build_performer_image_url(
+        9, updated_at="invalid"
+    ) == "/performer/9/image?default=true"
+
+
+def test_fetch_scene_candidates_handles_empty_and_unavailable_dependencies(monkeypatch):
+    assert scene_fetch.fetch_scene_candidates_by_performers(performer_ids=[]) == []
+
+    monkeypatch.setattr(scene_fetch.stash_db, "get_stash_sessionmaker", lambda: None)
+    assert scene_fetch.fetch_scene_candidates_by_performers(performer_ids=[1]) == []
+
+    monkeypatch.setattr(scene_fetch.stash_db, "get_stash_sessionmaker", lambda: object())
+    monkeypatch.setattr(
+        scene_fetch.stash_db, "get_first_available_table", lambda *args, **kwargs: None
+    )
+    assert scene_fetch.fetch_scene_candidates_by_performers(performer_ids=[1]) == []
+
+    metadata = sa.MetaData()
+    incomplete = sa.Table("links", metadata, sa.Column("scene_id", sa.Integer))
+    monkeypatch.setattr(
+        scene_fetch.stash_db,
+        "get_first_available_table",
+        lambda *args, **kwargs: incomplete,
+    )
+    assert scene_fetch.fetch_scene_candidates_by_performers(performer_ids=[1]) == []
+
+
+def test_fetch_scene_candidates_filters_sorts_and_limits(monkeypatch):
+    metadata = sa.MetaData()
+    links = sa.Table(
+        "performers_scenes",
+        metadata,
+        sa.Column("scene_id", sa.Integer),
+        sa.Column("performer_id", sa.Integer),
+    )
+    rows = [
+        SimpleNamespace(scene_id="10", performer_id="1"),
+        SimpleNamespace(scene_id=10, performer_id=2),
+        SimpleNamespace(scene_id=20, performer_id=1),
+        SimpleNamespace(scene_id=30, performer_id=1),
+        SimpleNamespace(scene_id="bad", performer_id=1),
+    ]
+    session = FakeSession(rows)
+    monkeypatch.setattr(
+        scene_fetch.stash_db, "get_stash_sessionmaker", lambda: lambda: session
+    )
+    monkeypatch.setattr(
+        scene_fetch.stash_db,
+        "get_first_available_table",
+        lambda *args, **kwargs: links,
+    )
+
+    result = scene_fetch.fetch_scene_candidates_by_performers(
+        performer_ids=[1, 2],
+        exclude_scene_ids=[30],
+        limit=2,
+    )
+
+    assert result == [(10, {1, 2}), (20, {1})]
+    assert "LIMIT" in str(session.statements[0])
+
+
+def _install_stash_schema(monkeypatch):
+    metadata = sa.MetaData()
+    tables = {}
+
+    tables["scenes"] = sa.Table(
+        "scenes",
+        metadata,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("title", sa.String),
+        sa.Column("rating", sa.Float),
+        sa.Column("studio_id", sa.Integer),
+        sa.Column("screenshot_path", sa.String),
+        sa.Column("preview_path", sa.String),
+        sa.Column("duration_ms", sa.Float),
+        sa.Column("play_duration", sa.Float),
+    )
+    tables["studios"] = sa.Table(
+        "studios",
+        metadata,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("name", sa.String),
+    )
+    tables["performers"] = sa.Table(
+        "performers",
+        metadata,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("name", sa.String),
+        sa.Column("image_path", sa.String),
+        sa.Column("updated_at", sa.String),
+    )
+    tables["performers_scenes"] = sa.Table(
+        "performers_scenes",
+        metadata,
+        sa.Column("scene_id", sa.Integer),
+        sa.Column("performer_id", sa.Integer),
+    )
+    tables["tags"] = sa.Table(
+        "tags",
+        metadata,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("name", sa.String),
+    )
+    tables["scene_tags"] = sa.Table(
+        "scene_tags",
+        metadata,
+        sa.Column("scene_id", sa.Integer),
+        sa.Column("tag_id", sa.Integer),
+    )
+    tables["scene_groups"] = sa.Table(
+        "scene_groups",
+        metadata,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("name", sa.String),
+    )
+    tables["scene_groups_scenes"] = sa.Table(
+        "scene_groups_scenes",
+        metadata,
+        sa.Column("scene_id", sa.Integer),
+        sa.Column("scene_group_id", sa.Integer),
+    )
+    tables["folders"] = sa.Table(
+        "folders",
+        metadata,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("path", sa.String),
+    )
+    tables["files"] = sa.Table(
+        "files",
+        metadata,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("basename", sa.String),
+        sa.Column("parent_folder_id", sa.Integer),
+        sa.Column("size", sa.Integer),
+    )
+    tables["video_files"] = sa.Table(
+        "video_files",
+        metadata,
+        sa.Column("file_id", sa.Integer, primary_key=True),
+        sa.Column("duration", sa.Float),
+        sa.Column("width", sa.Integer),
+        sa.Column("height", sa.Integer),
+    )
+    tables["scenes_files"] = sa.Table(
+        "scenes_files",
+        metadata,
+        sa.Column("scene_id", sa.Integer),
+        sa.Column("file_id", sa.Integer),
+        sa.Column("primary", sa.Boolean),
+    )
+    tables["files_fingerprints"] = sa.Table(
+        "files_fingerprints",
+        metadata,
+        sa.Column("file_id", sa.Integer),
+        sa.Column("type", sa.String),
+        sa.Column("value", sa.LargeBinary),
+    )
+
+    engine = sa.create_engine("sqlite+pysqlite:///:memory:")
+    metadata.create_all(engine)
+    with engine.begin() as connection:
+        connection.execute(
+            tables["scenes"].insert(),
+            [
+                {
+                    "id": 1,
+                    "title": "First",
+                    "rating": 88.6,
+                    "studio_id": 5,
+                    "screenshot_path": "ignored",
+                    "preview_path": "ignored",
+                    "duration_ms": 123000,
+                    "play_duration": 0,
+                },
+                {
+                    "id": 2,
+                    "title": "Second",
+                    "rating": None,
+                    "studio_id": None,
+                    "screenshot_path": None,
+                    "preview_path": None,
+                    "duration_ms": 0,
+                    "play_duration": 30,
+                },
+            ],
+        )
+        connection.execute(tables["studios"].insert(), [{"id": 5, "name": "Studio"}])
+        connection.execute(
+            tables["performers"].insert(),
+            [
+                {
+                    "id": 11,
+                    "name": "Alice",
+                    "image_path": None,
+                    "updated_at": "2024-01-02T03:04:05Z",
+                }
+            ],
+        )
+        connection.execute(
+            tables["performers_scenes"].insert(),
+            [{"scene_id": 1, "performer_id": 11}],
+        )
+        connection.execute(tables["tags"].insert(), [{"id": 21, "name": "Tag"}])
+        connection.execute(
+            tables["scene_tags"].insert(), [{"scene_id": 1, "tag_id": 21}]
+        )
+        connection.execute(
+            tables["scene_groups"].insert(), [{"id": 31, "name": "Series"}]
+        )
+        connection.execute(
+            tables["scene_groups_scenes"].insert(),
+            [{"scene_id": 1, "scene_group_id": 31}],
+        )
+        connection.execute(
+            tables["folders"].insert(), [{"id": 41, "path": "/media"}]
+        )
+        connection.execute(
+            tables["files"].insert(),
+            [{"id": 51, "basename": "video.mp4", "parent_folder_id": 41, "size": 99}],
+        )
+        connection.execute(
+            tables["video_files"].insert(),
+            [{"file_id": 51, "duration": 125.5, "width": 1920, "height": 1080}],
+        )
+        connection.execute(
+            tables["scenes_files"].insert(),
+            [{"scene_id": 1, "file_id": 51, "primary": True}],
+        )
+        connection.execute(
+            tables["files_fingerprints"].insert(),
+            [{"file_id": 51, "type": "md5", "value": b"\x01\x02"}],
+        )
+
+    session_factory = sessionmaker(bind=engine)
+
+    def get_table(name, required=False):
+        return tables.get(name)
+
+    def get_first(*names, required_columns=None):
+        for name in names:
+            table = tables.get(name)
+            if table is None:
+                continue
+            if required_columns and not all(table.c.get(column) is not None for column in required_columns):
+                continue
+            return table
+        return None
+
+    monkeypatch.setattr(scene_fetch.stash_db, "get_stash_sessionmaker", lambda: session_factory)
+    monkeypatch.setattr(scene_fetch.stash_db, "get_stash_table", get_table)
+    monkeypatch.setattr(scene_fetch.stash_db, "get_first_available_table", get_first)
+    monkeypatch.setattr(
+        scene_fetch,
+        "stash_api",
+        SimpleNamespace(api_key="key"),
+    )
+    return tables, engine
+
+
+def test_fetch_scenes_via_real_in_memory_schema(monkeypatch):
+    _, engine = _install_stash_schema(monkeypatch)
+
+    try:
+        scenes = scene_fetch._fetch_scenes_via_db([1, 2, 999])
+
+        assert set(scenes) == {1, 2}
+        assert scenes[1]["title"] == "First"
+        assert scenes[1]["rating100"] == 89
+        assert scenes[1]["studio"] == {"id": 5, "name": "Studio"}
+        assert scenes[1]["duration"] == 125.5
+        assert scenes[1]["paths"]["stream"] == "/scene/1/stream?apikey=key"
+        assert scenes[1]["performers"] == [
+            {
+                "id": 11,
+                "name": "Alice",
+                "image_path": "/performer/11/image?default=true&t=1704164645",
+            }
+        ]
+        assert scenes[1]["tags"] == [{"id": 21, "name": "Tag"}]
+        assert scenes[1]["series"] == [{"id": 31, "name": "Series"}]
+        assert scenes[1]["files"] == [
+            {
+                "id": 51,
+                "path": "/media/video.mp4",
+                "width": 1920,
+                "height": 1080,
+                "duration": 125.5,
+                "size": 99,
+                "primary": True,
+                "fingerprints": [{"type": "md5", "value": "0102"}],
+            }
+        ]
+        assert scenes[2]["duration"] == 30.0
+        assert scenes[2]["studio"] is None
+    finally:
+        engine.dispose()
+
+
+def test_fetch_scenes_via_db_handles_early_returns_and_errors(monkeypatch):
+    assert scene_fetch._fetch_scenes_via_db([]) == {}
+
+    monkeypatch.setattr(scene_fetch.stash_db, "get_stash_sessionmaker", lambda: None)
+    assert scene_fetch._fetch_scenes_via_db([1]) == {}
+
+    monkeypatch.setattr(
+        scene_fetch.stash_db, "get_stash_sessionmaker", lambda: lambda: FakeSession()
+    )
+    monkeypatch.setattr(scene_fetch.stash_db, "get_stash_table", lambda *args, **kwargs: None)
+    assert scene_fetch._fetch_scenes_via_db([1]) == {}
+
+    metadata = sa.MetaData()
+    table_without_id = sa.Table("scenes", metadata, sa.Column("title", sa.String))
+    monkeypatch.setattr(
+        scene_fetch.stash_db,
+        "get_stash_table",
+        lambda *args, **kwargs: table_without_id,
+    )
+    assert scene_fetch._fetch_scenes_via_db([1]) == {}
+
+    metadata = sa.MetaData()
+    scenes = sa.Table("scenes", metadata, sa.Column("id", sa.Integer))
+    monkeypatch.setattr(scene_fetch.stash_db, "get_stash_table", lambda *args, **kwargs: scenes)
+    monkeypatch.setattr(
+        scene_fetch.stash_db,
+        "get_stash_sessionmaker",
+        lambda: lambda: FakeSession(error=RuntimeError("database failed")),
+    )
+    assert scene_fetch._fetch_scenes_via_db([1]) == {}
+
+
+def test_fetch_scenes_by_ids_combines_database_results_and_stubs(monkeypatch):
+    monkeypatch.setattr(
+        scene_fetch,
+        "_fetch_scenes_via_db",
+        lambda ids: {1: {"id": 1, "title": "Found", "paths": {"preview": "p"}}},
+    )
+
+    result = scene_fetch.fetch_scenes_by_ids([1, 2, 1])
+
+    assert list(result) == [1, 2]
+    assert result[1]["title"] == "Found"
+    assert result[1]["paths"]["preview"] == "p"
+    assert result[2]["title"] == "Scene 2"
+    assert scene_fetch.fetch_scenes_by_ids([]) == {}
+
+
+def test_collect_tag_durations_handles_rows_and_invalid_values(monkeypatch):
+    assert tag_profiles.fetch_tag_durations_for_scenes(service="svc", scene_ids=[]) == (
+        {},
+        set(),
+    )
+
+    rows = [
+        SimpleNamespace(scene_id="1", tag_id="10", duration_s="2.5"),
+        SimpleNamespace(scene_id=1, tag_id=11, duration_s=0),
+        SimpleNamespace(scene_id=2, tag_id=None, duration_s=3),
+        SimpleNamespace(scene_id="bad", tag_id=12, duration_s=3),
+        SimpleNamespace(scene_id=3, tag_id=13, duration_s=-1),
+    ]
+    install_session(monkeypatch, tag_profiles, rows=rows)
+
+    result = tag_profiles.fetch_tag_durations_for_scenes(
+        service="svc", scene_ids=[1, 2, None]
+    )
+
+    assert result == ({1: {10: 2.5}}, {10})
+
+
+def test_accumulate_and_build_watched_tag_profiles(monkeypatch):
+    target = {1: 2.0}
+    tag_profiles._accumulate_tag_durations(
+        target, {1: "3", 2: 0, 3: "bad", 4: 4.5}
+    )
+    assert target == {1: 5.0, 4: 4.5}
+    tag_profiles._accumulate_tag_durations(target, {})
+
+    watch_results = {
+        1: ({"10": "2.5", "bad": 4, 11: -1}, 5),
+        2: ({12: 3}, 4),
+    }
+    monkeypatch.setattr(
+        tag_profiles,
+        "collect_watched_segment_tag_durations",
+        lambda *, scene_id, **kwargs: watch_results[scene_id],
+    )
+    monkeypatch.setattr(
+        tag_profiles,
+        "get_scene_tag_totals",
+        lambda *, scene_id, **kwargs: {20: 6} if scene_id == 1 else {},
+    )
+
+    watched, total, breakdown = tag_profiles.build_watched_tag_profile(
+        service="svc", scene_ids=[1, "invalid", 2]
+    )
+    assert watched == {10: 2.5, 12: 3.0}
+    assert total == 9
+    assert breakdown[1]["watch_tags"] == {10: 2.5}
+
+    full, total, breakdown = tag_profiles.build_watched_tag_profile(
+        service="svc", scene_ids=[1, 2], prefer_full_scene=True, min_confidence=0.5
+    )
+    assert full == {20: 6.0, 12: 3.0}
+    assert total == 9
+    assert breakdown[1]["fallback_tags"] == {20: 6.0}
+
+
+def test_tag_frequency_and_total_queries(monkeypatch):
+    assert tag_profiles.fetch_tag_document_frequencies(service="svc", tag_ids=[]) == {}
+
+    rows = [
+        SimpleNamespace(tag_id="1", scene_count="4"),
+        SimpleNamespace(tag_id="bad", scene_count=2),
+    ]
+    install_session(monkeypatch, tag_profiles, rows=rows)
+    assert tag_profiles.fetch_tag_document_frequencies(
+        service="svc", tag_ids=[1, None]
+    ) == {1: 4}
+
+    install_session(monkeypatch, tag_profiles, scalar="12")
+    assert tag_profiles.fetch_total_tagged_scene_count(service="svc") == 12
+    install_session(monkeypatch, tag_profiles, scalar="bad")
+    assert tag_profiles.fetch_total_tagged_scene_count(service="svc") == 0
+
+
+def test_collect_tag_durations_builds_aggregated_map(monkeypatch):
+    assert timespan_metrics.collect_tag_durations(service="svc", tag_ids=[]) == {}
+
+    rows = [(1, 10, 2.5), ("1", "10", 1.5), (2, 11, None)]
+    sessions = install_session(monkeypatch, timespan_metrics, rows=rows)
+
+    result = timespan_metrics.collect_tag_durations(
+        service="svc", tag_ids=[10, 11], scene_ids=[1, None]
+    )
+
+    assert result == {1: {10: 4.0}, 2: {11: 0.0}}
+    assert sessions[0].statements
+
+
+def test_interval_operations_cover_overlap_adjacency_and_empty_inputs():
+    assert timespan_metrics.merge_intervals([]) == []
+    assert timespan_metrics.merge_intervals(
+        [(5, 8), (1, 3), (3, 4), (7, 10)]
+    ) == [(1, 4), (5, 10)]
+    assert timespan_metrics.intersect_two(
+        [(0, 5), (8, 12)], [(3, 9), (10, 15)]
+    ) == [(3, 5), (8, 9), (10, 12)]
+    assert timespan_metrics.intersect_all([]) == []
+    assert timespan_metrics.intersect_all(
+        [[(0, 10)], [(2, 8)], [(4, 6)]]
+    ) == [(4, 6)]
+    assert timespan_metrics.intersect_all([[(0, 1)], [(2, 3)]]) == []
+
+
+def test_compute_cooccurrence_duration(monkeypatch):
+    assert timespan_metrics.compute_cooccurrence_duration(
+        service="svc", scene_id=1, tag_ids=[]
+    ) == 0
+
+    monkeypatch.setattr(timespan_metrics, "get_scene_timespans", lambda **kwargs: {})
+    assert timespan_metrics.compute_cooccurrence_duration(
+        service="svc", scene_id=1, tag_ids=[1]
+    ) == 0
+
+    buckets = {
+        "category": {
+            "1": [{"start": 0, "end": 5}, {"start": 8, "end": 10}],
+            "2": [{"start": 3, "end": 9}, {"start": 12, "end": 12}],
+        }
+    }
+    monkeypatch.setattr(
+        timespan_metrics, "get_scene_timespans", lambda **kwargs: buckets
+    )
+    assert timespan_metrics.compute_cooccurrence_duration(
+        service="svc", scene_id=1, tag_ids=[1, 2]
+    ) == 3
+    assert timespan_metrics.compute_cooccurrence_duration(
+        service="svc", scene_id=1, tag_ids=[1, 99]
+    ) == 0
+
+
+def test_fetch_scene_watch_intervals_repairs_and_filters_rows(monkeypatch):
+    rows = [
+        (0, 5, 5),
+        (4, 8, 4),
+        (10, 10, 3),
+        ("bad", 20, 1),
+        (30, "bad", 2),
+        (40, 40, 0),
+    ]
+    install_session(monkeypatch, timespan_metrics, rows=rows)
+
+    assert timespan_metrics._fetch_scene_watch_intervals(1) == [
+        (0.0, 8.0),
+        (10.0, 13.0),
+        (30.0, 32.0),
+    ]
+
+
+def test_collect_watched_segment_tag_durations(monkeypatch):
+    monkeypatch.setattr(timespan_metrics, "_fetch_scene_watch_intervals", lambda scene_id: [])
+    assert timespan_metrics.collect_watched_segment_tag_durations(
+        service="svc", scene_id=1
+    ) == ({}, 0.0)
+
+    monkeypatch.setattr(
+        timespan_metrics, "_fetch_scene_watch_intervals", lambda scene_id: [(0, 10)]
+    )
+    monkeypatch.setattr(timespan_metrics, "get_scene_timespans", lambda **kwargs: {})
+    assert timespan_metrics.collect_watched_segment_tag_durations(
+        service="svc", scene_id=1
+    ) == ({}, 10)
+
+    buckets = {
+        "one": {
+            "10": [
+                {"start": 1, "end": 4, "confidence": 0.9},
+                {"start": 3, "end": 8, "confidence": 0.8},
+                {"start": 9, "end": 11, "confidence": 0.1},
+                {"start": "bad", "end": 4, "confidence": 1},
+                "not-a-dict",
+            ],
+            "bad-tag": [{"start": 1, "end": 2}],
+            "11": [{"start": 2, "end": "bad", "confidence": 1}],
+            "12": [],
+        },
+        "two": {"10": [{"start": 20, "end": 25, "confidence": 1}]},
+    }
+    monkeypatch.setattr(
+        timespan_metrics, "get_scene_timespans", lambda **kwargs: buckets
+    )
+
+    assert timespan_metrics.collect_watched_segment_tag_durations(
+        service="svc", scene_id=1, min_confidence="0.5"
+    ) == ({10: 7.0}, 10)
+    assert timespan_metrics.collect_watched_segment_tag_durations(
+        service="svc", scene_id=1, min_confidence="invalid"
+    )[0][10] == 8.0
+
+
+def test_ensure_utc_handles_none_naive_and_aware_datetimes():
+    naive = datetime(2024, 1, 1, 12)
+    eastern = timezone(timedelta(hours=-5))
+    aware = datetime(2024, 1, 1, 7, tzinfo=eastern)
+
+    assert watch_history._ensure_utc(None) is None
+    assert watch_history._ensure_utc(naive) == naive.replace(tzinfo=timezone.utc)
+    assert watch_history._ensure_utc(aware) == datetime(
+        2024, 1, 1, 12, tzinfo=timezone.utc
+    )
+
+
+def test_load_watch_history_summary_filters_rows_and_normalizes_dates(monkeypatch):
+    entered = datetime(2024, 1, 1, 12)
+    rows = [
+        SimpleNamespace(
+            scene_id="1",
+            watched_s="12.5",
+            last_left=None,
+            last_entered=entered,
+            last_segment=None,
+        ),
+        SimpleNamespace(
+            scene_id=2,
+            watched_s=0,
+            last_left=entered,
+            last_entered=None,
+            last_segment=None,
+        ),
+        SimpleNamespace(
+            scene_id=3,
+            watched_s=3,
+            last_left=None,
+            last_entered=None,
+            last_segment=entered,
+        ),
+    ]
+    sessions = install_session(monkeypatch, watch_history, rows=rows)
+
+    result = watch_history.load_watch_history_summary(
+        recent_cutoff=entered,
+        min_watch_seconds=2,
+        limit=5,
+        order_desc=False,
+    )
+
+    assert result == [
+        {
+            "scene_id": 1,
+            "watched_s": 12.5,
+            "last_seen": entered.replace(tzinfo=timezone.utc),
+        },
+        {
+            "scene_id": 3,
+            "watched_s": 3.0,
+            "last_seen": entered.replace(tzinfo=timezone.utc),
+        },
+    ]
+    assert "LIMIT" in str(sessions[0].statements[0])
+
+
+def test_load_recent_watch_scene_ids_delegates_to_summary(monkeypatch):
+    monkeypatch.setattr(
+        watch_history,
+        "load_watch_history_summary",
+        lambda **kwargs: [{"scene_id": 1}, {"scene_id": 2}, {"scene_id": 1}],
+    )
+    assert watch_history.load_recent_watch_scene_ids(limit=2) == {1, 2}

--- a/backend/tests/test_recommendations_api_unit.py
+++ b/backend/tests/test_recommendations_api_unit.py
@@ -1,0 +1,335 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from stash_ai_server.api import recommendations
+from stash_ai_server.recommendations.models import RecContext
+from stash_ai_server.recommendations.models import RecommenderConfigField
+from stash_ai_server.recommendations.models import RecommenderDefinition
+
+
+def make_definition(**overrides):
+    values = {
+        "id": "example",
+        "label": "Example",
+        "contexts": [RecContext.global_feed],
+        "config": [],
+    }
+    values.update(overrides)
+    return RecommenderDefinition(**values)
+
+
+def make_query(**overrides):
+    values = {
+        "context": RecContext.global_feed,
+        "recommenderId": "example",
+        "config": {},
+        "seedSceneIds": None,
+        "limit": None,
+        "offset": 0,
+    }
+    values.update(overrides)
+    return recommendations.RecommendationQueryBody(**values)
+
+
+def test_validate_config_applies_defaults_constraints_and_warnings():
+    definition = make_definition(
+        config=[
+            RecommenderConfigField(
+                name="minimum",
+                label="Minimum",
+                type="number",
+                default=5,
+                min=1,
+                max=10,
+            ),
+            RecommenderConfigField(
+                name="slider",
+                label="Slider",
+                type="slider",
+                default=0.5,
+                min=0,
+                max=1,
+            ),
+            RecommenderConfigField(
+                name="required",
+                label="Required",
+                type="text",
+                default=None,
+                required=True,
+            ),
+        ]
+    )
+
+    result, warnings = recommendations._validate_config(
+        definition,
+        {
+            "minimum": -4,
+            "slider": 9,
+            "required": None,
+            "extra": "ignored",
+        },
+    )
+
+    assert result == {"minimum": 1, "slider": 1, "required": None}
+    assert warnings == [
+        "config.minimum below min; clamped",
+        "config.slider above max; clamped",
+        "config.required required but missing",
+        "config.extra ignored (undeclared)",
+    ]
+
+    result, warnings = recommendations._validate_config(
+        definition, {"minimum": "invalid"}
+    )
+    assert result["minimum"] == 5
+    assert "config.minimum invalid numeric; using default" in warnings
+    assert recommendations._validate_config(make_definition(), {"free": 1}) == (
+        {"free": 1},
+        [],
+    )
+
+
+def test_filter_persistable_config_respects_field_policy():
+    definition = make_definition(
+        config=[
+            RecommenderConfigField(name="saved", label="Saved", type="text"),
+            RecommenderConfigField(
+                name="temporary", label="Temporary", type="text", persist=False
+            ),
+        ]
+    )
+
+    assert recommendations._should_persist_field(definition.config[0]) is True
+    assert recommendations._should_persist_field(definition.config[1]) is False
+    assert recommendations._filter_persistable_config(
+        definition, {"saved": 1, "temporary": 2, "unknown": 3}
+    ) == {"saved": 1}
+    assert recommendations._filter_persistable_config(make_definition(), {}) == {}
+
+
+@pytest.mark.asyncio
+async def test_list_recommenders_handles_empty_saved_and_stale_preferences(monkeypatch):
+    monkeypatch.setattr(
+        recommendations.recommender_registry, "list_for_context", lambda context: []
+    )
+    empty = await recommendations.list_recommenders(RecContext.global_feed, object())
+    assert empty.defaultRecommenderId == ""
+    assert empty.recommenders == []
+
+    definition = make_definition()
+    monkeypatch.setattr(
+        recommendations.recommender_registry,
+        "list_for_context",
+        lambda context: [definition],
+    )
+    monkeypatch.setattr(
+        recommendations,
+        "get_preference",
+        lambda db, context: SimpleNamespace(
+            recommender_id="example", config={"saved": True}
+        ),
+    )
+    saved = await recommendations.list_recommenders(
+        RecContext.global_feed, object()
+    )
+    assert saved.defaultRecommenderId == "example"
+    assert saved.savedRecommenderId == "example"
+    assert saved.savedConfig == {"saved": True}
+
+    monkeypatch.setattr(
+        recommendations,
+        "get_preference",
+        lambda db, context: SimpleNamespace(recommender_id="removed", config={}),
+    )
+    stale = await recommendations.list_recommenders(
+        RecContext.global_feed, object()
+    )
+    assert stale.savedRecommenderId is None
+
+
+@pytest.mark.asyncio
+async def test_query_recommendations_rejects_invalid_resolution_context_and_seed(monkeypatch):
+    monkeypatch.setattr(recommendations.recommender_registry, "get", lambda rid: None)
+    with pytest.raises(HTTPException) as missing:
+        await recommendations.query_recommendations(make_query())
+    assert missing.value.status_code == 404
+
+    async def handler(_context, _request):
+        return []
+
+    definition = make_definition(contexts=[RecContext.similar_scene])
+    monkeypatch.setattr(
+        recommendations.recommender_registry,
+        "get",
+        lambda rid: (definition, handler),
+    )
+    with pytest.raises(HTTPException) as invalid_context:
+        await recommendations.query_recommendations(make_query())
+    assert invalid_context.value.status_code == 400
+
+    definition = make_definition(needs_seed_scenes=True)
+    monkeypatch.setattr(
+        recommendations.recommender_registry,
+        "get",
+        lambda rid: (definition, handler),
+    )
+    with pytest.raises(HTTPException) as missing_seed:
+        await recommendations.query_recommendations(make_query())
+    assert missing_seed.value.detail == "MISSING_SEED_SCENES"
+
+
+@pytest.mark.asyncio
+async def test_query_recommendations_validates_scenes_limits_seeds_and_local_pagination(
+    monkeypatch,
+):
+    captured = []
+
+    async def handler(context, request):
+        captured.append((context, request))
+        return [
+            {"id": 1, "paths": {}},
+            {"missing": "id"},
+            {"id": 2, "paths": None},
+            {"id": 3, "title": "Third"},
+        ]
+
+    definition = make_definition(
+        allows_multi_seed=False,
+        config=[
+            RecommenderConfigField(
+                name="score", label="Score", type="number", default=0, min=0, max=1
+            )
+        ],
+    )
+    monkeypatch.setattr(
+        recommendations.recommender_registry,
+        "get",
+        lambda rid: (definition, handler),
+    )
+
+    response = await recommendations.query_recommendations(
+        make_query(
+            config={"score": 2},
+            seedSceneIds=[10, 11],
+            offset=1,
+            limit=1,
+        )
+    )
+
+    assert captured[0][1].seedSceneIds == [10]
+    assert captured[0][1].config == {"score": 1}
+    assert [scene["id"] for scene in response.scenes] == [2]
+    assert response.meta == {
+        "total": 3,
+        "offset": 1,
+        "limit": 1,
+        "nextOffset": 2,
+        "hasMore": True,
+    }
+    assert response.warnings == [
+        "config.score above max; clamped",
+        "scene[1] validation failed",
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("handler_payload", "expected_total", "expected_more", "expected_next"),
+    [
+        ({"scenes": [{"id": 1}], "total": 10}, 10, True, 1),
+        ({"scenes": [{"id": 1}], "has_more": True}, 2, True, 1),
+        ({"scenes": [{"id": 1}], "total": 0, "has_more": False}, 1, False, None),
+    ],
+)
+async def test_query_recommendations_trusts_handler_pagination(
+    monkeypatch, handler_payload, expected_total, expected_more, expected_next
+):
+    async def handler(_context, _request):
+        return handler_payload
+
+    monkeypatch.setattr(
+        recommendations.recommender_registry,
+        "get",
+        lambda rid: (make_definition(), handler),
+    )
+
+    response = await recommendations.query_recommendations(
+        make_query(limit=5, offset=0)
+    )
+
+    assert response.meta["total"] == expected_total
+    assert response.meta["hasMore"] is expected_more
+    assert response.meta["nextOffset"] == expected_next
+
+
+@pytest.mark.asyncio
+async def test_query_recommendations_translates_handler_errors(monkeypatch):
+    async def handler(_context, _request):
+        raise RuntimeError("handler failed")
+
+    monkeypatch.setattr(
+        recommendations.recommender_registry,
+        "get",
+        lambda rid: (make_definition(), handler),
+    )
+
+    with pytest.raises(HTTPException) as raised:
+        await recommendations.query_recommendations(make_query())
+
+    assert raised.value.status_code == 500
+    assert raised.value.detail == "recommender_execution_failed: handler failed"
+
+
+@pytest.mark.asyncio
+async def test_upsert_preference_validates_registry_context_and_persistence(monkeypatch):
+    payload = recommendations.PreferenceUpsertBody(
+        context=RecContext.global_feed,
+        recommenderId="example",
+        config={"saved": "yes", "temporary": "no"},
+    )
+    monkeypatch.setattr(recommendations.recommender_registry, "get", lambda rid: None)
+    with pytest.raises(HTTPException) as missing:
+        await recommendations.upsert_recommendation_preference(payload, object())
+    assert missing.value.status_code == 404
+
+    definition = make_definition(contexts=[RecContext.similar_scene])
+    monkeypatch.setattr(
+        recommendations.recommender_registry,
+        "get",
+        lambda rid: (definition, object()),
+    )
+    with pytest.raises(HTTPException) as invalid:
+        await recommendations.upsert_recommendation_preference(payload, object())
+    assert invalid.value.status_code == 400
+
+    definition = make_definition(
+        config=[
+            RecommenderConfigField(name="saved", label="Saved", type="text"),
+            RecommenderConfigField(
+                name="temporary", label="Temporary", type="text", persist=False
+            ),
+        ]
+    )
+    captured = []
+    monkeypatch.setattr(
+        recommendations.recommender_registry,
+        "get",
+        lambda rid: (definition, object()),
+    )
+
+    def save(db, context, recommender_id, config):
+        captured.append((db, context, recommender_id, config))
+        return SimpleNamespace(recommender_id=recommender_id, config=config)
+
+    monkeypatch.setattr(recommendations, "save_preference", save)
+    db = object()
+    response = await recommendations.upsert_recommendation_preference(payload, db)
+
+    assert captured == [
+        (db, RecContext.global_feed, "example", {"saved": "yes"})
+    ]
+    assert response.config == {"saved": "yes"}

--- a/backend/tests/test_runtime_unit.py
+++ b/backend/tests/test_runtime_unit.py
@@ -1,0 +1,180 @@
+"""Unit tests for in-process backend refresh coordination."""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from stash_ai_server.core import runtime
+
+
+@pytest.fixture(autouse=True)
+def reset_runtime_state():
+    original_handlers = dict(runtime._REFRESH_HANDLERS)
+    original_handler_counter = runtime._handler_counter
+    original_refresh_task = runtime._refresh_task
+    original_refresh_pending = runtime._refresh_pending
+    original_refresh_running = runtime._refresh_running
+    original_refresh_again = runtime._refresh_again
+
+    runtime._REFRESH_HANDLERS.clear()
+    runtime._handler_counter = 0
+    runtime._refresh_task = None
+    runtime._refresh_pending = False
+    runtime._refresh_running = False
+    runtime._refresh_again = False
+    try:
+        yield
+    finally:
+        task = runtime._refresh_task
+        if task is not None and not task.done():
+            task.cancel()
+        runtime._REFRESH_HANDLERS.clear()
+        runtime._REFRESH_HANDLERS.update(original_handlers)
+        runtime._handler_counter = original_handler_counter
+        runtime._refresh_task = original_refresh_task
+        runtime._refresh_pending = original_refresh_pending
+        runtime._refresh_running = original_refresh_running
+        runtime._refresh_again = original_refresh_again
+
+
+def test_register_refresh_handler_validates_inputs_and_replaces_names():
+    first = lambda: None
+    second = lambda: None
+
+    with pytest.raises(ValueError, match="name is required"):
+        runtime.register_backend_refresh_handler("", first)
+    with pytest.raises(TypeError, match="must be callable"):
+        runtime.register_backend_refresh_handler("invalid", None)
+
+    runtime.register_backend_refresh_handler("same", first, priority=5)
+    runtime.register_backend_refresh_handler("same", second, priority=-1)
+
+    priority, order, callback = runtime._REFRESH_HANDLERS["same"]
+    assert priority == -1
+    assert order == 2
+    assert callback is second
+
+
+@pytest.mark.asyncio
+async def test_execute_refresh_orders_sync_and_async_handlers():
+    calls = []
+
+    def later():
+        calls.append("later")
+
+    async def first():
+        await asyncio.sleep(0)
+        calls.append("first")
+
+    runtime.register_backend_refresh_handler("later", later, priority=5)
+    runtime.register_backend_refresh_handler("first", first, priority=-1)
+    runtime._refresh_task = object()
+
+    await runtime._execute_refresh(0)
+
+    assert calls == ["first", "later"]
+    assert runtime._refresh_running is False
+    assert runtime._refresh_task is None
+
+
+@pytest.mark.asyncio
+async def test_execute_refresh_continues_after_handler_failure(caplog):
+    calls = []
+
+    def broken():
+        raise RuntimeError("refresh failed")
+
+    runtime.register_backend_refresh_handler("broken", broken)
+    runtime.register_backend_refresh_handler("working", lambda: calls.append("working"))
+
+    await runtime._execute_refresh(0)
+
+    assert calls == ["working"]
+    assert "backend refresh handler broken failed" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_execute_refresh_handles_empty_registry_and_delay(monkeypatch, caplog):
+    delays = []
+
+    async def fake_sleep(delay):
+        delays.append(delay)
+
+    monkeypatch.setattr(
+        runtime,
+        "asyncio",
+        SimpleNamespace(sleep=fake_sleep),
+    )
+    caplog.set_level("INFO", logger=runtime.__name__)
+
+    await runtime._execute_refresh(0.25)
+
+    assert delays == [0.25]
+    assert "no handlers registered" in caplog.text
+
+
+def test_schedule_backend_restart_runs_synchronously_without_event_loop():
+    calls = []
+    runtime.register_backend_refresh_handler("sync", lambda: calls.append("sync"))
+
+    runtime.schedule_backend_restart(0)
+
+    assert calls == ["sync"]
+    assert runtime._refresh_pending is False
+    assert runtime._refresh_running is False
+
+
+@pytest.mark.asyncio
+async def test_schedule_backend_restart_requeues_during_active_refresh():
+    calls = []
+
+    def handler():
+        calls.append(len(calls) + 1)
+        if len(calls) == 1:
+            runtime.schedule_backend_restart(0)
+
+    runtime.register_backend_refresh_handler("handler", handler)
+    runtime.schedule_backend_restart(0)
+    first_task = runtime._refresh_task
+    assert first_task is not None
+
+    await first_task
+    for _ in range(10):
+        if len(calls) == 2:
+            break
+        await asyncio.sleep(0)
+    second_task = runtime._refresh_task
+    if second_task is not None:
+        await second_task
+
+    assert calls == [1, 2]
+    assert runtime._refresh_again is False
+
+
+def test_schedule_backend_restart_coalesces_pending_requests():
+    runtime._refresh_pending = True
+
+    runtime.schedule_backend_restart(0)
+
+    assert runtime._refresh_pending is True
+    assert runtime._refresh_running is False
+
+
+@pytest.mark.asyncio
+async def test_start_refresh_task_clamps_negative_delay(monkeypatch):
+    delays = []
+
+    async def fake_execute(delay):
+        delays.append(delay)
+
+    monkeypatch.setattr(runtime, "_execute_refresh", fake_execute)
+    loop = asyncio.get_running_loop()
+
+    runtime._start_refresh_task(loop, -5)
+    task = runtime._refresh_task
+    assert task is not None
+    await task
+
+    assert delays == [0.0]
+    assert runtime._refresh_running is True

--- a/backend/tests/test_service_registry_unit.py
+++ b/backend/tests/test_service_registry_unit.py
@@ -1,0 +1,282 @@
+"""Unit tests for service discovery, settings and task-manager registration."""
+
+from types import SimpleNamespace
+
+from stash_ai_server.actions.models import ContextRule
+from stash_ai_server.actions.registry import action
+from stash_ai_server.models.plugin import PluginSetting
+from stash_ai_server.services import registry as service_registry
+
+
+class FakeQuery:
+    def __init__(self, rows=(), error=None):
+        self.rows = list(rows)
+        self.error = error
+
+    def filter(self, *_args):
+        if self.error:
+            raise self.error
+        return self
+
+    def all(self):
+        if self.error:
+            raise self.error
+        return list(self.rows)
+
+
+class FakeSession:
+    def __init__(self, rows=(), error=None, close_error=None):
+        self.rows = rows
+        self.error = error
+        self.close_error = close_error
+        self.closed = False
+
+    def query(self, _model):
+        return FakeQuery(self.rows, self.error)
+
+    def close(self):
+        self.closed = True
+        if self.close_error:
+            raise self.close_error
+
+
+class FakeActionRegistry:
+    def __init__(self):
+        self.registered = []
+        self.unregistered = []
+
+    def register(self, definition, handler):
+        self.registered.append((definition, handler))
+
+    def unregister_service(self, service_name):
+        self.unregistered.append(service_name)
+
+
+class FakeTaskManager:
+    def __init__(self, *, configure_error=False, remove_error=False):
+        self.configure_error = configure_error
+        self.remove_error = remove_error
+        self.configured = []
+        self.removed = []
+
+    def configure_service(self, name, concurrency, server_url):
+        if self.configure_error:
+            raise RuntimeError("configure failed")
+        self.configured.append((name, concurrency, server_url))
+
+    def remove_service(self, name):
+        if self.remove_error:
+            raise RuntimeError("remove failed")
+        self.removed.append(name)
+
+
+class ExampleService(service_registry.ServiceBase):
+    name = "example"
+    max_concurrency = 3
+    server_url = "http://example.test"
+
+    @action(
+        id="example.action",
+        label="Example",
+        contexts=[ContextRule(pages=["scenes"], selection="single")],
+    )
+    async def run(self, *_args):
+        return None
+
+
+def test_service_base_resolves_explicit_module_and_fallback_plugin_names():
+    class Explicit(service_registry.ServiceBase):
+        name = "explicit-service"
+        plugin_name = "explicit-plugin"
+
+    class ModuleDerived(service_registry.ServiceBase):
+        name = "derived-service"
+
+    class Fallback(service_registry.ServiceBase):
+        name = "fallback-service"
+
+    ModuleDerived.__module__ = "stash_ai_server.plugins.sample_plugin.service"
+
+    assert Explicit().plugin_name == "explicit-plugin"
+    assert ModuleDerived().plugin_name == "sample_plugin"
+    assert Fallback().plugin_name == "fallback-service"
+    assert Fallback().connectivity() == "unknown"
+
+
+def test_service_base_loads_settings_and_closes_session(monkeypatch):
+    rows = [
+        PluginSetting(
+            plugin_name="example",
+            key="custom",
+            value="value",
+            default_value="default",
+        ),
+        PluginSetting(
+            plugin_name="example",
+            key="fallback",
+            value=None,
+            default_value=42,
+        ),
+        PluginSetting(
+            plugin_name="example",
+            key="empty",
+            value=None,
+            default_value=None,
+        ),
+    ]
+    session = FakeSession(rows)
+    monkeypatch.setattr(service_registry, "get_session", lambda: session)
+
+    assert ExampleService()._load_settings() == {
+        "custom": "value",
+        "fallback": 42,
+    }
+    assert session.closed is True
+
+
+def test_service_base_handles_session_query_and_close_failures(monkeypatch):
+    monkeypatch.setattr(
+        service_registry,
+        "get_session",
+        lambda: (_ for _ in ()).throw(RuntimeError("open failed")),
+    )
+    assert ExampleService()._load_settings() == {}
+
+    query_failure = FakeSession(error=RuntimeError("query failed"))
+    monkeypatch.setattr(service_registry, "get_session", lambda: query_failure)
+    assert ExampleService()._load_settings() == {}
+    assert query_failure.closed is True
+
+    close_failure = FakeSession(
+        [
+            PluginSetting(
+                plugin_name="example",
+                key="retained",
+                value="value",
+                default_value=None,
+            )
+        ],
+        close_error=RuntimeError("close failed"),
+    )
+    monkeypatch.setattr(service_registry, "get_session", lambda: close_failure)
+    assert ExampleService()._load_settings() == {"retained": "value"}
+    assert close_failure.closed is True
+
+
+def test_registry_registers_actions_and_configures_task_manager(monkeypatch):
+    actions = FakeActionRegistry()
+    manager = FakeTaskManager()
+    monkeypatch.setattr(service_registry, "action_registry", actions)
+    registry = service_registry.ServiceRegistry()
+    registry.set_task_manager(manager)
+    service = ExampleService()
+
+    registry.register(service)
+
+    assert registry.list() == [service]
+    assert registry.get("example") is service
+    assert registry.get("missing") is None
+    assert len(actions.registered) == 1
+    definition, handler = actions.registered[0]
+    assert definition.service == "example"
+    assert handler.__self__ is service
+    assert manager.configured == [("example", 3, "http://example.test")]
+
+
+def test_registry_replaces_and_unregisters_services(monkeypatch):
+    actions = FakeActionRegistry()
+    manager = FakeTaskManager(remove_error=True)
+    monkeypatch.setattr(service_registry, "action_registry", actions)
+    registry = service_registry.ServiceRegistry()
+    registry.set_task_manager(manager)
+    first = ExampleService()
+    second = ExampleService()
+
+    registry.register(first)
+    registry.register(second)
+    registry.unregister("missing")
+    registry.unregister("example")
+
+    assert registry.list() == []
+    assert actions.unregistered == ["example", "example"]
+
+
+def test_registry_tracks_pending_configuration_and_retries(monkeypatch):
+    actions = FakeActionRegistry()
+    monkeypatch.setattr(service_registry, "action_registry", actions)
+    registry = service_registry.ServiceRegistry()
+    failing = FakeTaskManager(configure_error=True)
+    registry.set_task_manager(failing)
+    service = ExampleService()
+
+    registry.register(service)
+    assert registry._pending_task_configs == {"example"}
+
+    working = FakeTaskManager()
+    registry.set_task_manager(working)
+    assert registry._pending_task_configs == set()
+    assert working.configured == [("example", 3, "http://example.test")]
+
+
+def test_registry_unregisters_all_services_owned_by_plugin(monkeypatch):
+    actions = FakeActionRegistry()
+    manager = FakeTaskManager()
+    monkeypatch.setattr(service_registry, "action_registry", actions)
+    registry = service_registry.ServiceRegistry()
+    registry.set_task_manager(manager)
+
+    first = ExampleService()
+    first.name = "first"
+    first.plugin_name = "shared-plugin"
+    second = ExampleService()
+    second.name = "second"
+    second.plugin_name = "shared-plugin"
+    other = ExampleService()
+    other.name = "other"
+    other.plugin_name = "other-plugin"
+    registry.register(first)
+    registry.register(second)
+    registry.register(other)
+
+    registry.unregister_by_plugin("shared-plugin")
+
+    assert [service.name for service in registry.list()] == ["other"]
+    assert manager.removed == ["first", "second"]
+
+
+def test_pending_configuration_discards_missing_service():
+    registry = service_registry.ServiceRegistry()
+    registry._pending_task_configs.add("missing")
+    registry._task_manager = FakeTaskManager()
+
+    registry._configure_pending_services()
+
+    assert registry._pending_task_configs == set()
+
+
+def test_refresh_registered_services_reloads_and_reconfigures(monkeypatch):
+    reloaded = []
+
+    class Reloadable:
+        name = "reloadable"
+
+        def reload_settings(self):
+            reloaded.append(self.name)
+
+    class Broken:
+        name = "broken"
+
+        def reload_settings(self):
+            raise RuntimeError("reload failed")
+
+    configured = []
+    fake_services = SimpleNamespace(
+        list=lambda: [Reloadable(), Broken()],
+        _configure_service=lambda service: configured.append(service.name),
+    )
+    monkeypatch.setattr(service_registry, "services", fake_services)
+
+    service_registry._refresh_registered_services()
+
+    assert reloaded == ["reloadable"]
+    assert configured == ["reloadable"]

--- a/backend/tests/test_services_base_unit.py
+++ b/backend/tests/test_services_base_unit.py
@@ -1,0 +1,382 @@
+"""Unit tests for remote service HTTP and readiness primitives."""
+
+import asyncio
+import json
+from types import SimpleNamespace
+
+import httpx
+import pytest
+from pydantic import BaseModel, TypeAdapter, ValidationError
+
+from stash_ai_server.services import base
+
+
+class Payload(BaseModel):
+    value: int
+
+
+def _attach_transport(client: base.HTTPClient, handler):
+    client._client = httpx.AsyncClient(
+        base_url=client.base_url,
+        transport=httpx.MockTransport(handler),
+    )
+    return client
+
+
+def test_timeout_and_text_helpers():
+    timeout = httpx.Timeout(5)
+
+    assert base._coerce_timeout(timeout) is timeout
+    assert base._coerce_timeout(2).connect == 2
+    assert base._coerce_timeout(None) is base._DEFAULT_TIMEOUT
+    assert base._trim(None) is None
+    assert base._trim("short", limit=10) == "short"
+    assert base._trim("longer than limit", limit=10) == "longer ..."
+
+
+def test_connectivity_probe_description_includes_available_details():
+    probe = base.ConnectivityProbe(
+        True,
+        "ready",
+        status_code=200,
+        latency_ms=12.34,
+        error="none",
+    )
+
+    assert probe.describe() == "ready; status=200; 12.3ms; error=none"
+    assert base.ConnectivityProbe(True, "ready").describe() == "ready"
+
+
+def test_http_client_validates_and_normalizes_base_urls_and_paths():
+    with pytest.raises(ValueError, match="base_url is required"):
+        base.HTTPClient("")
+
+    client = base.HTTPClient("http://example.test/")
+
+    assert client.base_url == "http://example.test"
+    assert client._normalize_path("") == "/"
+    assert client._normalize_path("ready") == "/ready"
+    assert client._normalize_path("/ready") == "/ready"
+    assert client._normalize_path("https://other.test/path") == (
+        "https://other.test/path"
+    )
+
+
+@pytest.mark.asyncio
+async def test_http_client_creates_reuses_and_closes_underlying_client():
+    client = base.HTTPClient(
+        "http://example.test",
+        timeout=3,
+        headers={"X-Test": "yes"},
+        verify=False,
+        follow_redirects=False,
+    )
+
+    first, second = await asyncio.gather(
+        client._get_client(),
+        client._get_client(),
+    )
+
+    assert first is second
+    assert first.headers["User-Agent"] == "stash-ai-server-plugin/1.0"
+    assert first.headers["X-Test"] == "yes"
+    await client.close()
+    assert client._client is None
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_http_methods_forward_payloads_and_decode_json():
+    requests = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            json={"value": len(requests)},
+            request=request,
+        )
+
+    client = _attach_transport(base.HTTPClient("http://example.test"), handler)
+
+    assert await client.get("items", expect_json=True) == {"value": 1}
+    assert await client.post(
+        "/items",
+        json={"name": "item"},
+        expect_json=True,
+    ) == {"value": 2}
+    assert await client.put(
+        "/items/1",
+        content=b"payload",
+        expect_json=True,
+    ) == {"value": 3}
+    response = await client.delete("/items/1")
+
+    assert response.status_code == 200
+    assert [request.method for request in requests] == [
+        "GET",
+        "POST",
+        "PUT",
+        "DELETE",
+    ]
+    assert json.loads(requests[1].content) == {"name": "item"}
+    assert requests[2].content == b"payload"
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_http_client_validates_response_models_and_type_adapters():
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/list":
+            return httpx.Response(
+                200,
+                json=[{"value": 1}, {"value": 2}],
+                request=request,
+            )
+        return httpx.Response(200, json={"value": 3}, request=request)
+
+    client = _attach_transport(base.HTTPClient("http://example.test"), handler)
+
+    assert await client.get("/one", response_model=Payload) == Payload(value=3)
+    adapter = TypeAdapter(list[Payload])
+    assert await client.get("/list", response_model=adapter) == [
+        Payload(value=1),
+        Payload(value=2),
+    ]
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_http_client_handles_empty_invalid_and_error_responses():
+    def handler(request: httpx.Request) -> httpx.Response:
+        responses = {
+            "/empty": httpx.Response(204, request=request),
+            "/invalid-json": httpx.Response(200, text="not-json", request=request),
+            "/invalid-model": httpx.Response(
+                200,
+                json={"value": "not-an-integer"},
+                request=request,
+            ),
+            "/error": httpx.Response(500, text="failure", request=request),
+        }
+        return responses[request.url.path]
+
+    client = _attach_transport(base.HTTPClient("http://example.test"), handler)
+
+    assert await client.get("/empty", expect_json=True) is None
+    with pytest.raises(ValueError, match="Expected JSON payload"):
+        await client.get("/empty", response_model=Payload)
+    with pytest.raises(ValueError, match="not valid JSON"):
+        await client.get("/invalid-json", expect_json=True)
+    with pytest.raises(ValidationError):
+        await client.get("/invalid-model", response_model=Payload)
+    with pytest.raises(httpx.HTTPStatusError):
+        await client.get("/error")
+
+    response = await client.request(
+        "GET",
+        "/error",
+        raise_for_status=False,
+    )
+    assert response.status_code == 500
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_check_ready_reports_success_http_errors_and_network_errors():
+    success = _attach_transport(
+        base.HTTPClient("http://example.test"),
+        lambda request: httpx.Response(200, request=request),
+    )
+    unavailable = _attach_transport(
+        base.HTTPClient("http://example.test"),
+        lambda request: httpx.Response(
+            503,
+            text="x" * 250,
+            request=request,
+        ),
+    )
+
+    def network_error(request: httpx.Request):
+        raise httpx.ConnectError("connection failed", request=request)
+
+    disconnected = _attach_transport(
+        base.HTTPClient("http://example.test"),
+        network_error,
+    )
+
+    ready_probe = await success.check_ready()
+    unavailable_probe = await unavailable.check_ready()
+    network_probe = await disconnected.check_ready()
+
+    assert ready_probe.ok is True
+    assert ready_probe.status == "ready"
+    assert ready_probe.status_code == 200
+    assert unavailable_probe.ok is False
+    assert unavailable_probe.status == "status-503"
+    assert unavailable_probe.status_code == 503
+    assert unavailable_probe.error.endswith("...")
+    assert len(unavailable_probe.error) == 200
+    assert network_probe.ok is False
+    assert network_probe.status == "network-error"
+    assert "connection failed" in network_probe.error
+    await success.close()
+    await unavailable.close()
+    await disconnected.close()
+
+
+class FakeHTTPClient:
+    def __init__(self, base_url, probes=()):
+        self._base_url = base_url
+        self.probes = list(probes)
+        self.ready_calls = []
+        self.closed = False
+
+    @property
+    def base_url(self):
+        return self._base_url
+
+    async def check_ready(self, path):
+        self.ready_calls.append(path)
+        return self.probes.pop(0)
+
+    async def close(self):
+        self.closed = True
+
+
+class ExampleRemoteService(base.RemoteServiceBase):
+    name = "example-remote"
+
+    def __init__(self):
+        self.created_clients = []
+        super().__init__()
+
+    def build_http_client(self, base_url):
+        client = FakeHTTPClient(base_url)
+        self.created_clients.append(client)
+        return client
+
+
+def test_remote_service_requires_url_and_builds_normalized_client(monkeypatch):
+    service = ExampleRemoteService()
+    monkeypatch.setattr(base.settings, "docker_mode", False)
+
+    with pytest.raises(RuntimeError, match="does not define a server_url"):
+        _ = service.http
+
+    service.server_url = "http://example.test/"
+    first = service.http
+    assert first.base_url == "http://example.test"
+    assert service.http is first
+
+    service.server_url = "http://other.test/"
+    second = service.http
+    assert second.base_url == "http://other.test"
+    assert second is not first
+    assert first.closed is True
+
+
+@pytest.mark.asyncio
+async def test_remote_service_replaces_client_inside_running_loop(monkeypatch):
+    service = ExampleRemoteService()
+    monkeypatch.setattr(base.settings, "docker_mode", False)
+    service.server_url = "http://first.test"
+    first = service.http
+
+    service.server_url = "http://second.test"
+    second = service.http
+    await asyncio.sleep(0)
+
+    assert second is not first
+    assert first.closed is True
+    await service.close()
+    assert second.closed is True
+    assert service._http_client is None
+
+
+@pytest.mark.asyncio
+async def test_remote_service_without_url_is_local_and_ready():
+    service = ExampleRemoteService()
+
+    assert await service.ensure_remote_ready() is True
+    assert service.connectivity() == "local: no server_url configured"
+    assert service.connectivity_details()["state"] == "local"
+
+
+@pytest.mark.asyncio
+async def test_remote_service_caches_success_and_force_rechecks(monkeypatch):
+    service = ExampleRemoteService()
+    service.server_url = "http://example.test"
+    client = FakeHTTPClient(
+        service.server_url,
+        [
+            base.ConnectivityProbe(True, "ready", 200, latency_ms=1),
+            base.ConnectivityProbe(True, "ready", 200, latency_ms=2),
+        ],
+    )
+    service._http_client = client
+    monkeypatch.setattr(
+        base,
+        "time",
+        SimpleNamespace(monotonic=lambda: 100.0),
+    )
+    monkeypatch.setattr(base.settings, "docker_mode", False)
+
+    assert await service.ensure_remote_ready() is True
+    assert await service.ensure_remote_ready() is True
+    assert len(client.ready_calls) == 1
+    assert service.connectivity().startswith("ready: ready; status=200")
+    assert service.connectivity_details()["last_ready_error"] is None
+
+    assert await service.ensure_remote_ready(force=True) is True
+    assert len(client.ready_calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_remote_service_tracks_failure_waiting_and_recovery(monkeypatch):
+    service = ExampleRemoteService()
+    service.server_url = "http://example.test"
+    client = FakeHTTPClient(
+        service.server_url,
+        [
+            base.ConnectivityProbe(False, "status-503", 503, "unavailable", 2),
+            base.ConnectivityProbe(True, "ready", 200, latency_ms=1),
+        ],
+    )
+    service._http_client = client
+    monkeypatch.setattr(
+        base,
+        "time",
+        SimpleNamespace(monotonic=lambda: 200.0),
+    )
+    monkeypatch.setattr(base.settings, "docker_mode", False)
+
+    assert await service.ensure_remote_ready() is False
+    assert service.connectivity().startswith("unreachable: status-503")
+    assert await service.ensure_remote_ready() is False
+    assert service.connectivity() == "waiting: status-503; status=503; 2.0ms; error=unavailable"
+    assert len(client.ready_calls) == 1
+
+    assert await service.ensure_remote_ready(force=True) is True
+    assert service.connectivity().startswith("ready:")
+
+
+@pytest.mark.asyncio
+async def test_remote_service_honors_recent_failure_backoff(monkeypatch):
+    service = ExampleRemoteService()
+    service.server_url = "http://example.test"
+    client = FakeHTTPClient(service.server_url)
+    service._http_client = client
+    service._last_ready_failure = 95.0
+    service._last_ready_error = "previous failure"
+    service._next_ready_attempt = 0.0
+    monkeypatch.setattr(
+        base,
+        "time",
+        SimpleNamespace(monotonic=lambda: 100.0),
+    )
+    monkeypatch.setattr(base.settings, "docker_mode", False)
+
+    assert await service.ensure_remote_ready() is False
+    assert service.connectivity() == "unreachable: previous failure"
+    assert client.ready_calls == []

--- a/backend/tests/test_settings_registry_unit.py
+++ b/backend/tests/test_settings_registry_unit.py
@@ -1,0 +1,207 @@
+"""Unit tests for plugin setting registration and loading."""
+
+from stash_ai_server.models.plugin import PluginSetting
+from stash_ai_server.plugin_runtime import settings_registry
+
+
+class FakeScalars:
+    def __init__(self, rows):
+        self.rows = rows
+
+    def all(self):
+        return list(self.rows)
+
+
+class FakeResult:
+    def __init__(self, rows):
+        self.rows = rows
+
+    def scalars(self):
+        return FakeScalars(self.rows)
+
+
+class FakeSession:
+    def __init__(self, rows=(), *, execute_error: Exception | None = None):
+        self.rows = list(rows)
+        self.execute_error = execute_error
+        self.added = []
+        self.commits = 0
+        self.closed = False
+
+    def execute(self, _statement):
+        if self.execute_error is not None:
+            raise self.execute_error
+        return FakeResult(self.rows)
+
+    def add(self, row):
+        self.added.append(row)
+        self.rows.append(row)
+
+    def commit(self):
+        self.commits += 1
+
+    def close(self):
+        self.closed = True
+
+
+def _setting(**overrides):
+    values = {
+        "plugin_name": "example",
+        "key": "mode",
+        "type": "string",
+        "label": "Mode",
+        "description": "Original description",
+        "default_value": "old",
+        "options": ["old"],
+        "value": "custom",
+    }
+    values.update(overrides)
+    return PluginSetting(**values)
+
+
+def test_register_settings_adds_normalized_definitions_and_skips_missing_keys():
+    session = FakeSession()
+
+    settings_registry.register_settings(
+        session,
+        "example",
+        [
+            {
+                "name": "mode",
+                "type": "select",
+                "label": "Mode",
+                "help": "Select a mode",
+                "default": "null",
+                "options": ["one", "null"],
+            },
+            {"label": "Missing key"},
+        ],
+    )
+
+    assert session.commits == 1
+    assert len(session.added) == 1
+    row = session.added[0]
+    assert row.plugin_name == "example"
+    assert row.key == "mode"
+    assert row.type == "select"
+    assert row.label == "Mode"
+    assert row.description == "Select a mode"
+    assert row.default_value is None
+    assert row.options == ["one", None]
+    assert row.value is None
+
+
+def test_register_settings_updates_metadata_without_overwriting_custom_value():
+    row = _setting()
+    session = FakeSession([row])
+
+    settings_registry.register_settings(
+        session,
+        "example",
+        [
+            {
+                "key": "mode",
+                "type": "select",
+                "label": "New mode",
+                "description": "New description",
+                "default": "new",
+                "options": ["new", "other"],
+            }
+        ],
+    )
+
+    assert session.commits == 1
+    assert row.type == "select"
+    assert row.label == "New mode"
+    assert row.description == "New description"
+    assert row.default_value == "new"
+    assert row.options == ["new", "other"]
+    assert row.value == "custom"
+
+
+def test_register_settings_populates_missing_value_and_avoids_noop_commit():
+    row = _setting(default_value="default", value=None)
+    session = FakeSession([row])
+
+    settings_registry.register_settings(
+        session,
+        "example",
+        [
+            {
+                "key": "mode",
+                "type": "string",
+                "label": "Mode",
+                "description": "Original description",
+                "default": "default",
+                "options": ["old"],
+            }
+        ],
+    )
+    assert row.value == "default"
+    assert session.commits == 1
+
+    settings_registry.register_settings(
+        session,
+        "example",
+        [
+            {
+                "key": "mode",
+                "type": "string",
+                "label": "Mode",
+                "description": "Original description",
+                "default": "default",
+                "options": ["old"],
+            }
+        ],
+    )
+    assert session.commits == 1
+
+
+def test_load_plugin_settings_resolves_values_and_closes_session(monkeypatch):
+    rows = [
+        _setting(key="custom", value="value", default_value="default"),
+        _setting(key="fallback", value=None, default_value=42),
+        _setting(key="empty", value=None, default_value=None),
+    ]
+    session = FakeSession(rows)
+    monkeypatch.setattr(
+        "stash_ai_server.db.session.get_session_local",
+        lambda: lambda: session,
+    )
+
+    assert settings_registry.load_plugin_settings("example") == {
+        "custom": "value",
+        "fallback": 42,
+    }
+    assert session.closed is True
+
+
+def test_load_plugin_settings_handles_factory_and_query_failures(monkeypatch):
+    monkeypatch.setattr(
+        "stash_ai_server.db.session.get_session_local",
+        lambda: (_ for _ in ()).throw(RuntimeError("factory failed")),
+    )
+    assert settings_registry.load_plugin_settings("example") == {}
+
+    session = FakeSession(execute_error=RuntimeError("query failed"))
+    monkeypatch.setattr(
+        "stash_ai_server.db.session.get_session_local",
+        lambda: lambda: session,
+    )
+    assert settings_registry.load_plugin_settings("example") == {}
+    assert session.closed is True
+
+
+def test_load_plugin_settings_ignores_close_failures(monkeypatch):
+    session = FakeSession([_setting()])
+
+    def fail_close():
+        raise RuntimeError("close failed")
+
+    session.close = fail_close
+    monkeypatch.setattr(
+        "stash_ai_server.db.session.get_session_local",
+        lambda: lambda: session,
+    )
+
+    assert settings_registry.load_plugin_settings("example") == {"mode": "custom"}

--- a/backend/tests/test_stash_api_unit.py
+++ b/backend/tests/test_stash_api_unit.py
@@ -1,0 +1,487 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from stash_ai_server.utils import stash_api as stash_api_module
+
+
+def make_api(interface=None):
+    api = object.__new__(stash_api_module.StashAPI)
+    api.tag_id_cache = {}
+    api.tag_name_cache = {}
+    api.stash_interface = interface
+    api.stash_url = ""
+    api.api_key = None
+    api._effective_url = None
+    return api
+
+
+class InterfaceStub:
+    def __init__(self):
+        self.calls = []
+        self.tags = {}
+        self.images = []
+        self.scenes = []
+        self.scene = None
+        self.markers = []
+
+    def find_tag(self, value, create=False):
+        self.calls.append(("find_tag", value, create))
+        return self.tags.get(value)
+
+    def create_tag(self, payload):
+        self.calls.append(("create_tag", payload))
+        return {"id": 42}
+
+    def find_tags(self, **kwargs):
+        self.calls.append(("find_tags", kwargs))
+        return [{"id": 1, "name": "One"}, {"id": 2, "name": "Two"}]
+
+    def update_images(self, payload):
+        self.calls.append(("update_images", payload))
+
+    def find_images(self, **kwargs):
+        self.calls.append(("find_images", kwargs))
+        return self.images
+
+    def find_scenes(self, **kwargs):
+        self.calls.append(("find_scenes", kwargs))
+        return self.scenes
+
+    def find_scene(self, **kwargs):
+        self.calls.append(("find_scene", kwargs))
+        return self.scene
+
+    def update_scenes(self, payload):
+        self.calls.append(("update_scenes", payload))
+
+    def destroy_markers(self, marker_ids):
+        self.calls.append(("destroy_markers", marker_ids))
+
+    def find_scene_markers(self, **kwargs):
+        self.calls.append(("find_scene_markers", kwargs))
+        return self.markers
+
+    def create_scene_marker(self, payload):
+        self.calls.append(("create_scene_marker", payload))
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (None, None),
+        ("", ""),
+        (12, 12),
+        ("/scene/1?x=1", "/scene/1?x=1"),
+        ("http://stash:9999/scene/1?x=1", "/scene/1?x=1"),
+        ("https://stash:9999", "/"),
+    ],
+)
+def test_to_relative_path(value, expected):
+    assert stash_api_module._to_relative_path(value) == expected
+
+
+def test_refresh_configuration_disables_client_without_url(monkeypatch):
+    values = {"STASH_URL": "", "STASH_API_KEY": "key"}
+    monkeypatch.setattr(stash_api_module, "sys_get", values.get)
+    api = make_api(InterfaceStub())
+    api.tag_id_cache["old"] = 1
+    api.tag_name_cache[1] = "old"
+
+    api.refresh_configuration()
+
+    assert api.stash_url == ""
+    assert api.api_key == "key"
+    assert api.stash_interface is None
+    assert api.tag_id_cache == {}
+    assert api.tag_name_cache == {}
+
+
+def test_refresh_configuration_builds_effective_client_and_clears_caches(monkeypatch):
+    values = {"STASH_URL": "http://localhost:9999", "STASH_API_KEY": "key"}
+    interface = InterfaceStub()
+    monkeypatch.setattr(stash_api_module, "sys_get", values.get)
+    monkeypatch.setattr(
+        stash_api_module,
+        "dockerize_localhost",
+        lambda url, enabled: "http://host.docker.internal:9999",
+    )
+    monkeypatch.setattr(
+        stash_api_module, "_construct_stash_interface", lambda url, key: interface
+    )
+    api = make_api()
+    api.tag_id_cache["old"] = 1
+
+    api.refresh_configuration()
+
+    assert api.stash_url == "http://localhost:9999"
+    assert api._effective_url == "http://host.docker.internal:9999"
+    assert api.api_key == "key"
+    assert api.stash_interface is interface
+    assert api.tag_id_cache == {}
+
+
+def test_refresh_configuration_preserves_previous_client_on_constructor_error(monkeypatch):
+    values = {"STASH_URL": "http://new", "STASH_API_KEY": "new-key"}
+    previous = InterfaceStub()
+    monkeypatch.setattr(stash_api_module, "sys_get", values.get)
+    monkeypatch.setattr(stash_api_module, "dockerize_localhost", lambda url, enabled: url)
+    monkeypatch.setattr(
+        stash_api_module,
+        "_construct_stash_interface",
+        lambda *args: (_ for _ in ()).throw(RuntimeError("invalid")),
+    )
+    api = make_api(previous)
+    api.stash_url = "http://old"
+    api.api_key = "old-key"
+
+    api.refresh_configuration()
+
+    assert api.stash_interface is previous
+    assert api.stash_url == "http://old"
+    assert api.api_key == "old-key"
+
+
+def test_fetch_tag_id_uses_cache_finds_and_creates_tags():
+    interface = InterfaceStub()
+    interface.tags = {
+        "existing": {"id": "3"},
+        "created-root": {"id": 4},
+        "existing-child": {"id": 5},
+    }
+    api = make_api(interface)
+    api.tag_id_cache["cached"] = 2
+
+    assert api.fetch_tag_id("cached") == 2
+    assert api.fetch_tag_id("missing") is None
+    assert api.fetch_tag_id("existing") == 3
+    assert api.fetch_tag_id("created-root", create_if_missing=True) == 4
+    added = {}
+    assert (
+        api.fetch_tag_id(
+            "new-child",
+            parent_id=9,
+            create_if_missing=True,
+            use_cache=False,
+            add_to_cache=added,
+        )
+        == 42
+    )
+    assert api.fetch_tag_id(
+        "existing-child", parent_id=9, create_if_missing=True, use_cache=False
+    ) == 5
+    assert added == {"new-child": 42}
+    assert api.tag_name_cache[42] == "new-child"
+
+
+def test_tag_lookup_helpers_cache_results_and_handle_errors():
+    interface = InterfaceStub()
+    interface.tags = {7: {"id": 7, "name": "Seven"}}
+    api = make_api(interface)
+
+    assert api.get_tags_with_parent(1) == {"One": 1, "Two": 2}
+    assert api.get_stash_tag_name(7) == "Seven"
+    assert api.get_stash_tag_name(7) == "Seven"
+    assert api.get_stash_tag_name(8) is None
+
+    interface.find_tag = lambda value, create=False: (_ for _ in ()).throw(
+        RuntimeError("failed")
+    )
+    assert api.get_stash_tag_name(9) is None
+
+
+@pytest.mark.asyncio
+async def test_image_tag_mutations_sync_and_async():
+    interface = InterfaceStub()
+    api = make_api(interface)
+
+    api.add_tags_to_images([1], [2])
+    api.remove_tags_from_images([1], [3])
+    await api.add_tags_to_images_async([4], [5])
+    await api.remove_tags_from_images_async([4], [6])
+
+    assert [call[1] for call in interface.calls] == [
+        {"ids": [1], "tag_ids": {"ids": [2], "mode": "ADD"}},
+        {"ids": [1], "tag_ids": {"ids": [3], "mode": "REMOVE"}},
+        {"ids": [4], "tag_ids": {"ids": [5], "mode": "ADD"}},
+        {"ids": [4], "tag_ids": {"ids": [6], "mode": "REMOVE"}},
+    ]
+
+
+def test_get_image_paths_handles_missing_client_malformed_rows_and_errors():
+    api = make_api()
+    assert api.get_image_paths([1]) == {}
+
+    interface = InterfaceStub()
+    interface.images = [
+        {"id": "1", "files": [{"path": "/one.jpg"}]},
+        {"id": "bad", "files": []},
+        {},
+    ]
+    api.stash_interface = interface
+    assert api.get_image_paths([1, 2]) == {1: "/one.jpg"}
+
+    interface.find_images = lambda **kwargs: (_ for _ in ()).throw(
+        RuntimeError("failed")
+    )
+    assert api.get_image_paths([1]) == {}
+
+
+def test_get_image_paths_and_tags_normalizes_partial_payloads():
+    api = make_api()
+    assert api.get_image_paths_and_tags([1]) == {}
+
+    interface = InterfaceStub()
+    interface.images = [
+        {
+            "id": "1",
+            "files": [{"path": "/one.jpg"}],
+            "tags": [{"id": "2"}, {"id": "bad"}, {}],
+        },
+        {"id": 2, "files": [], "tags": None},
+        {"id": "bad", "files": [{"path": "/bad"}]},
+    ]
+    api.stash_interface = interface
+
+    assert api.get_image_paths_and_tags([1, 2]) == {
+        1: {"path": "/one.jpg", "tag_ids": [2]},
+        2: {"path": None, "tag_ids": []},
+    }
+
+    interface.find_images = lambda **kwargs: (_ for _ in ()).throw(
+        RuntimeError("failed")
+    )
+    assert api.get_image_paths_and_tags([1]) == {}
+
+
+@pytest.mark.asyncio
+async def test_async_image_read_wrappers_delegate_to_sync_methods(monkeypatch):
+    api = make_api()
+    monkeypatch.setattr(api, "get_image_paths", lambda ids: {1: "path"})
+    monkeypatch.setattr(
+        api, "get_image_paths_and_tags", lambda ids: {1: {"path": "path"}}
+    )
+    monkeypatch.setattr(api, "get_all_images", lambda: ["1"])
+
+    assert await api.get_image_paths_async([1]) == {1: "path"}
+    assert await api.get_image_paths_and_tags_async([1]) == {1: {"path": "path"}}
+    assert await api.get_all_images_async() == ["1"]
+
+
+def test_get_all_images_and_scenes_handle_success_missing_clients_and_errors():
+    api = make_api()
+    assert api.get_all_images() == []
+    assert api.get_all_scenes() == []
+
+    interface = InterfaceStub()
+    interface.images = [{"id": 1}, {"missing": 2}]
+    interface.scenes = [{"id": 3}, {"missing": 4}]
+    api.stash_interface = interface
+    assert api.get_all_images() == ["1"]
+    assert api.get_all_scenes() == ["3"]
+
+    interface.find_images = lambda **kwargs: (_ for _ in ()).throw(
+        RuntimeError("images")
+    )
+    interface.find_scenes = lambda **kwargs: (_ for _ in ()).throw(
+        RuntimeError("scenes")
+    )
+    assert api.get_all_images() == []
+    assert api.get_all_scenes() == []
+
+
+@pytest.mark.asyncio
+async def test_scene_read_wrapper_and_metadata_paths(monkeypatch):
+    api = make_api()
+    assert api.get_scene_path_and_tags_and_duration(1) == (None, [], None)
+
+    interface = InterfaceStub()
+    api.stash_interface = interface
+    assert api.get_scene_path_and_tags_and_duration(1) == (None, [], None)
+    interface.scene = {
+        "files": [{"path": "/video.mp4", "duration": 12.5}],
+        "tags": [{"id": 3}, {}],
+    }
+    assert api.get_scene_path_and_tags_and_duration(1) == (
+        "/video.mp4",
+        [3],
+        12.5,
+    )
+
+    monkeypatch.setattr(
+        api,
+        "get_scene_path_and_tags_and_duration",
+        lambda scene_id: ("path", [1], 2),
+    )
+    assert await api.get_scene_path_and_tags_and_duration_async(1) == (
+        "path",
+        [1],
+        2,
+    )
+
+
+class PaginatedInterface:
+    def __init__(self, pages):
+        self.pages = pages
+        self.calls = []
+
+    def find_scenes(self, *, filter, **kwargs):
+        self.calls.append((filter, kwargs))
+        return self.pages.get((filter["per_page"], filter["page"]), [])
+
+
+def test_fetch_scenes_by_tag_paginated_normalizes_urls_and_probes():
+    scene = {
+        "id": 1,
+        "paths": {
+            "screenshot": "http://stash:9999/scene/1/screenshot?x=1",
+            "preview": "/scene/1/preview",
+        },
+        "image_path": "http://stash:9999/image/1",
+        "files": [{"path": "http://stash:9999/media/video.mp4"}],
+    }
+    interface = PaginatedInterface(
+        {
+            (2, 1): [scene, {"id": 2}],
+            (2, 2): [{"id": 3}, {"id": 4}],
+            (1, 3): [{"id": 5}],
+        }
+    )
+    api = make_api(interface)
+
+    scenes, total, has_more = api.fetch_scenes_by_tag_paginated(
+        tag_id=9, offset=-2, limit=2
+    )
+
+    assert [item["id"] for item in scenes] == [1, 2]
+    assert total == 6
+    assert has_more is True
+    assert scenes[0]["paths"]["screenshot"] == "/scene/1/screenshot?x=1"
+    assert scenes[0]["image_path"] == "/image/1"
+    assert scenes[0]["files"][0]["path"] == "/media/video.mp4"
+
+
+def test_fetch_scenes_by_tag_paginated_handles_partial_pages_invalid_limit_and_errors():
+    api = make_api(PaginatedInterface({(2, 2): [{"id": 3}]}))
+    assert api.fetch_scenes_by_tag_paginated(1, 2, 2) == (
+        [{"id": 3, "paths": {}}],
+        3,
+        False,
+    )
+    assert api.fetch_scenes_by_tag_paginated(1, 0, 0) == ([], 0, False)
+
+    api.stash_interface = SimpleNamespace(
+        find_scenes=lambda **kwargs: (_ for _ in ()).throw(RuntimeError("failed"))
+    )
+    assert api.fetch_scenes_by_tag_paginated(1, 0, 2) == ([], 0, False)
+
+
+@pytest.mark.asyncio
+async def test_scene_tag_mutations_and_async_wrappers():
+    interface = InterfaceStub()
+    api = make_api(interface)
+
+    api.add_tags_to_scene(1, [])
+    api.remove_tags_from_scene(1, [])
+    api.add_tags_to_scene(1, [2])
+    api.remove_tags_from_scene(1, [3])
+    await api.add_tags_to_scene_async(4, [5])
+    await api.remove_tags_from_scene_async(4, [6])
+
+    updates = [call[1] for call in interface.calls if call[0] == "update_scenes"]
+    assert updates == [
+        {"ids": [1], "tag_ids": {"ids": [2], "mode": "ADD"}},
+        {"ids": [1], "tag_ids": {"ids": [3], "mode": "REMOVE"}},
+        {"ids": [4], "tag_ids": {"ids": [5], "mode": "ADD"}},
+        {"ids": [4], "tag_ids": {"ids": [6], "mode": "REMOVE"}},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_marker_operations_cover_empty_matches_and_async_wrappers():
+    interface = InterfaceStub()
+    api = make_api(interface)
+
+    api.destroy_markers_with_tags(1, [2])
+    interface.markers = [{"id": 10}, {"id": 11}]
+    api.destroy_markers_with_tags(1, [2])
+    api.create_scene_markers(1, {(2, "Tag"): [(1.0, 3.0), (4.0, 5.0)]})
+    await api.destroy_scene_markers_async([12])
+    await api.destroy_markers_with_tags_async(1, [2])
+    await api.create_scene_markers_async(2, {(3, "Other"): [(0.0, 1.0)]})
+
+    assert ("destroy_markers", [10, 11]) in interface.calls
+    assert ("destroy_markers", [12]) in interface.calls
+    created = [call[1] for call in interface.calls if call[0] == "create_scene_marker"]
+    assert created[0] == {
+        "scene_id": 1,
+        "seconds": 1.0,
+        "end_seconds": 3.0,
+        "primary_tag_id": 2,
+        "tag_ids": [2],
+        "title": "Tag",
+    }
+    assert len(created) == 3
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (None, False),
+        ("", False),
+        ("   ", False),
+        ("REPLACE_WITH_API_KEY", False),
+        ("key", True),
+    ],
+)
+def test_have_valid_api_key(value, expected):
+    assert stash_api_module._have_valid_api_key(value) is expected
+
+
+def test_construct_stash_interface_parses_urls_and_api_keys(monkeypatch):
+    captured = []
+
+    class CapturingInterface:
+        def __init__(self, connection):
+            captured.append(connection)
+
+    monkeypatch.setattr(stash_api_module, "StashInterface", CapturingInterface)
+
+    stash_api_module._construct_stash_interface("//localhost:9999", "key")
+    stash_api_module._construct_stash_interface("localhost", None)
+    stash_api_module._construct_stash_interface("https://example.com", "")
+    stash_api_module._construct_stash_interface("http://example.com:bad", None)
+
+    assert captured == [
+        {"Scheme": "http", "Host": "localhost", "Port": 9999, "ApiKey": "key"},
+        {"Scheme": "http", "Host": "localhost", "Port": 80},
+        {"Scheme": "https", "Host": "example.com", "Port": 443},
+        {"Scheme": "http", "Host": "example.com", "Port": 80},
+    ]
+
+
+def test_global_singleton_proxy_and_refresh_handler(monkeypatch):
+    created = []
+
+    class FakeAPI:
+        def __init__(self):
+            self.value = 7
+            self.refreshed = False
+            created.append(self)
+
+        def refresh_configuration(self):
+            self.refreshed = True
+
+    monkeypatch.setattr(stash_api_module, "StashAPI", FakeAPI)
+    monkeypatch.setattr(stash_api_module, "_stash_api_instance", None)
+
+    first = stash_api_module.get_stash_api()
+    second = stash_api_module.get_stash_api()
+    assert first is second
+    assert stash_api_module.StashAPIProxy().value == 7
+
+    monkeypatch.setattr(stash_api_module, "stash_api", first)
+    stash_api_module._refresh_stash_api()
+    assert first.refreshed is True

--- a/backend/tests/test_system_health_unit.py
+++ b/backend/tests/test_system_health_unit.py
@@ -1,0 +1,275 @@
+"""Unit tests for system health probes and status aggregation."""
+
+from contextlib import nullcontext
+from types import SimpleNamespace
+
+import pytest
+
+from stash_ai_server.api import system as system_api
+from stash_ai_server.schemas.health import HealthComponent, HealthStatus
+
+
+class FakeStashInterface:
+    def __init__(self, error=None):
+        self.error = error
+        self.calls = []
+
+    def find_tags(self, **kwargs):
+        self.calls.append(kwargs)
+        if self.error is not None:
+            raise self.error
+        return []
+
+
+class FakeDatabaseSession:
+    def __init__(self, error=None):
+        self.error = error
+        self.executed = []
+
+    def execute(self, statement):
+        self.executed.append(str(statement))
+        if self.error is not None:
+            raise self.error
+
+
+def _stash_client(*, url="", api_key="", interface=None):
+    return SimpleNamespace(
+        stash_url=url,
+        _effective_url=url or None,
+        api_key=api_key,
+        stash_interface=interface,
+    )
+
+
+@pytest.mark.asyncio
+async def test_stash_api_probe_warns_when_url_is_missing(monkeypatch):
+    monkeypatch.setattr(
+        system_api,
+        "stash_api",
+        _stash_client(api_key="secret"),
+    )
+
+    component = await system_api._probe_stash_api()
+
+    assert component.status == HealthStatus.WARN
+    assert component.message == "Stash URL not configured"
+    assert component.details == {
+        "configured_url": None,
+        "effective_url": None,
+        "api_key_configured": True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_stash_api_probe_errors_when_client_cannot_initialize(monkeypatch):
+    monkeypatch.setattr(
+        system_api,
+        "stash_api",
+        _stash_client(url="http://stash.test"),
+    )
+
+    component = await system_api._probe_stash_api()
+
+    assert component.status == HealthStatus.ERROR
+    assert component.message == "Unable to initialize Stash API client"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("api_key", "expected_status", "expected_message"),
+    [
+        ("secret", HealthStatus.OK, "Connected to Stash API"),
+        (
+            "",
+            HealthStatus.WARN,
+            "Connected to Stash API (API key not configured)",
+        ),
+    ],
+)
+async def test_stash_api_probe_reports_success_and_missing_key_warning(
+    monkeypatch,
+    api_key,
+    expected_status,
+    expected_message,
+):
+    interface = FakeStashInterface()
+    monkeypatch.setattr(
+        system_api,
+        "stash_api",
+        _stash_client(
+            url="http://stash.test",
+            api_key=api_key,
+            interface=interface,
+        ),
+    )
+
+    component = await system_api._probe_stash_api()
+
+    assert component.status == expected_status
+    assert component.message == expected_message
+    assert interface.calls == [
+        {"filter": {"per_page": 1, "page": 1}, "fragment": "id"}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_stash_api_probe_reports_request_failure(monkeypatch):
+    monkeypatch.setattr(
+        system_api,
+        "stash_api",
+        _stash_client(
+            url="http://stash.test",
+            api_key="secret",
+            interface=FakeStashInterface(RuntimeError("offline")),
+        ),
+    )
+
+    component = await system_api._probe_stash_api()
+
+    assert component.status == HealthStatus.ERROR
+    assert component.message == "Failed to reach Stash API"
+    assert component.details["last_error"] == "offline"
+
+
+@pytest.mark.asyncio
+async def test_stash_database_probe_warns_when_path_is_missing(monkeypatch):
+    monkeypatch.setattr(system_api, "sys_get", lambda _key: None)
+    monkeypatch.setattr(
+        system_api,
+        "stash_db",
+        SimpleNamespace(get_stash_sessionmaker=lambda: None),
+    )
+
+    component = await system_api._probe_stash_database()
+
+    assert component.status == HealthStatus.WARN
+    assert component.message == "Stash database path not configured"
+    assert component.details["configured_path"] is None
+    assert component.details["last_error"] == (
+        "Stash database is not configured or unavailable"
+    )
+
+
+@pytest.mark.asyncio
+async def test_stash_database_probe_reports_missing_file(monkeypatch, tmp_path):
+    missing_path = tmp_path / "missing.sqlite"
+    monkeypatch.setattr(system_api, "sys_get", lambda _key: str(missing_path))
+    monkeypatch.setattr(
+        system_api,
+        "mutate_path_for_backend",
+        lambda path: path,
+    )
+    monkeypatch.setattr(
+        system_api,
+        "stash_db",
+        SimpleNamespace(get_stash_sessionmaker=lambda: None),
+    )
+
+    component = await system_api._probe_stash_database()
+
+    assert component.status == HealthStatus.ERROR
+    assert component.message == "Configured database path was not found"
+    assert component.details["path_exists"] is False
+
+
+@pytest.mark.asyncio
+async def test_stash_database_probe_reports_accessible_database(
+    monkeypatch,
+    tmp_path,
+):
+    database_path = tmp_path / "stash.sqlite"
+    database_path.touch()
+    session = FakeDatabaseSession()
+    monkeypatch.setattr(system_api, "sys_get", lambda _key: str(database_path))
+    monkeypatch.setattr(
+        system_api,
+        "mutate_path_for_backend",
+        lambda path: path,
+    )
+    monkeypatch.setattr(
+        system_api,
+        "stash_db",
+        SimpleNamespace(
+            get_stash_sessionmaker=lambda: lambda: nullcontext(session)
+        ),
+    )
+
+    component = await system_api._probe_stash_database()
+
+    assert component.status == HealthStatus.OK
+    assert component.message == "Stash database accessible"
+    assert component.details["path_exists"] is True
+    assert session.executed == ["SELECT 1"]
+
+
+@pytest.mark.asyncio
+async def test_stash_database_probe_reports_open_and_mutation_failures(
+    monkeypatch,
+    tmp_path,
+):
+    database_path = tmp_path / "stash.sqlite"
+    database_path.touch()
+    monkeypatch.setattr(system_api, "sys_get", lambda _key: str(database_path))
+    monkeypatch.setattr(
+        system_api,
+        "mutate_path_for_backend",
+        lambda _path: (_ for _ in ()).throw(ValueError("mapping failed")),
+    )
+    monkeypatch.setattr(
+        system_api,
+        "stash_db",
+        SimpleNamespace(
+            get_stash_sessionmaker=lambda: lambda: nullcontext(
+                FakeDatabaseSession(RuntimeError("database offline"))
+            )
+        ),
+    )
+
+    component = await system_api._probe_stash_database()
+
+    assert component.status == HealthStatus.ERROR
+    assert component.message == "Failed to open Stash database"
+    assert component.details["mutation_error"] == "mapping failed"
+    assert component.details["last_error"] == "database offline"
+
+
+@pytest.mark.asyncio
+async def test_system_health_uses_worst_component_and_version_payload(
+    monkeypatch,
+):
+    stash_component = HealthComponent(
+        status=HealthStatus.WARN,
+        message="stash warning",
+    )
+    database_component = HealthComponent(
+        status=HealthStatus.ERROR,
+        message="database error",
+    )
+
+    async def probe_stash():
+        return stash_component
+
+    async def probe_database():
+        return database_component
+
+    monkeypatch.setattr(system_api, "_probe_stash_api", probe_stash)
+    monkeypatch.setattr(system_api, "_probe_stash_database", probe_database)
+    monkeypatch.setattr(
+        system_api,
+        "get_version_payload",
+        lambda db: {
+            "version": "1.2.3",
+            "db_alembic_head": "revision",
+            "frontend_min_version": "1.0.0",
+        },
+    )
+    db = object()
+
+    snapshot = await system_api.get_system_health(db)
+
+    assert snapshot.status == HealthStatus.ERROR
+    assert snapshot.stash_api is stash_component
+    assert snapshot.database is database_component
+    assert snapshot.backend_version == "1.2.3"
+    assert snapshot.db_alembic_head == "revision"
+    assert snapshot.version_payload["frontend_min_version"] == "1.0.0"

--- a/backend/tests/test_system_settings_unit.py
+++ b/backend/tests/test_system_settings_unit.py
@@ -1,0 +1,313 @@
+"""Unit tests for database-backed system settings."""
+
+import sys
+
+import pytest
+
+from stash_ai_server.core import system_settings
+from stash_ai_server.models.plugin import PluginSetting
+
+
+class FakeResult:
+    def __init__(self, rows=(), scalar=None):
+        self.rows = list(rows)
+        self.scalar = scalar
+
+    def scalars(self):
+        return self
+
+    def all(self):
+        return list(self.rows)
+
+    def scalar_one_or_none(self):
+        if self.scalar is not None:
+            return self.scalar
+        return self.rows[0] if self.rows else None
+
+
+class FakeSession:
+    def __init__(self, rows=(), *, connection_error=None):
+        self.rows = list(rows)
+        self.connection_error = connection_error
+        self.added = []
+        self.commits = 0
+        self.close_calls = 0
+        self.executed = []
+
+    def execute(self, statement):
+        statement_text = str(statement)
+        self.executed.append(statement_text)
+        if statement_text.strip() == "SELECT 1":
+            if self.connection_error is not None:
+                raise self.connection_error
+            return FakeResult()
+        return FakeResult(self.rows)
+
+    def add(self, row):
+        self.added.append(row)
+        self.rows.append(row)
+
+    def commit(self):
+        self.commits += 1
+
+    def close(self):
+        self.close_calls += 1
+
+
+@pytest.fixture(autouse=True)
+def reset_system_settings(monkeypatch):
+    original_cache = dict(system_settings._CACHE)
+    monkeypatch.setattr(system_settings, "_session_factory", None)
+    monkeypatch.setattr(system_settings, "_CACHE_LOADED", False)
+    system_settings._CACHE.clear()
+    try:
+        yield
+    finally:
+        system_settings._CACHE.clear()
+        system_settings._CACHE.update(original_cache)
+
+
+@pytest.mark.parametrize(
+    ("setting_type", "value", "expected"),
+    [
+        ("string", None, None),
+        ("string", "value", "value"),
+        ("number", "2.5", 2.5),
+        ("number", "invalid", "invalid"),
+        ("boolean", True, True),
+        ("boolean", 0, False),
+        ("boolean", 2, True),
+        ("boolean", "YES", True),
+        ("boolean", "off", False),
+        ("boolean", object(), False),
+    ],
+)
+def test_coerce_value_handles_supported_types(setting_type, value, expected):
+    actual = system_settings._coerce_value(setting_type, value)
+    if setting_type == "boolean":
+        assert actual is expected
+    else:
+        assert actual == expected
+
+
+def test_session_factory_override_and_default_session(monkeypatch):
+    custom_session = object()
+    system_settings.set_session_factory(lambda: custom_session)
+    assert system_settings._get_session() is custom_session
+
+    default_session = object()
+    monkeypatch.setattr(system_settings, "_session_factory", None)
+    monkeypatch.setattr(
+        "stash_ai_server.db.session.get_session",
+        lambda: default_session,
+    )
+    assert system_settings._get_session() is default_session
+
+
+def test_seed_system_settings_creates_rows_from_defaults_and_environment(
+    monkeypatch,
+):
+    definitions = [
+        {
+            "key": "FEATURE_ENABLED",
+            "type": "boolean",
+            "label": "Feature enabled",
+            "description": "Toggle",
+            "default": False,
+        },
+        {
+            "key": "RETRY_COUNT",
+            "type": "number",
+            "label": "Retry count",
+            "default": 3,
+            "options": ["null", 5],
+        },
+    ]
+    session = FakeSession()
+    monkeypatch.setattr(system_settings, "_DEFS", definitions)
+    monkeypatch.setenv("FEATURE_ENABLED", "true")
+    monkeypatch.delenv("RETRY_COUNT", raising=False)
+    system_settings.set_session_factory(lambda: session)
+    system_settings._CACHE["stale"] = "value"
+    system_settings._CACHE_LOADED = True
+
+    system_settings.seed_system_settings()
+
+    assert session.commits == 1
+    assert session.close_calls == 1
+    assert [row.key for row in session.added] == [
+        "FEATURE_ENABLED",
+        "RETRY_COUNT",
+    ]
+    assert session.added[0].value is True
+    assert session.added[1].value == 3
+    assert session.added[1].options == [None, 5]
+    assert system_settings._CACHE == {}
+    assert system_settings._CACHE_LOADED is False
+
+
+def test_seed_system_settings_updates_metadata_and_avoids_noop_commit(
+    monkeypatch,
+):
+    definition = {
+        "key": "RETRY_COUNT",
+        "type": "number",
+        "label": "Retry count",
+        "description": "Current description",
+        "default": 3,
+        "options": [1, 3],
+    }
+    existing = PluginSetting(
+        plugin_name=system_settings.SYSTEM_PLUGIN_NAME,
+        key="RETRY_COUNT",
+        type="string",
+        label="Old label",
+        description="Old description",
+        default_value=3,
+        options=None,
+        value=3,
+    )
+    session = FakeSession([existing])
+    monkeypatch.setattr(system_settings, "_DEFS", [definition])
+    monkeypatch.setenv("RETRY_COUNT", "7")
+    system_settings.set_session_factory(lambda: session)
+
+    system_settings.seed_system_settings()
+
+    assert existing.type == "number"
+    assert existing.label == "Retry count"
+    assert existing.description == "Current description"
+    assert existing.options == [1, 3]
+    assert existing.value == 7.0
+    assert session.commits == 1
+
+    monkeypatch.delenv("RETRY_COUNT")
+    system_settings.seed_system_settings()
+    assert session.commits == 1
+
+
+def test_seed_system_settings_skips_when_database_is_unavailable(monkeypatch):
+    session = FakeSession(connection_error=RuntimeError("offline"))
+    monkeypatch.setattr(system_settings, "_DEFS", [])
+    system_settings.set_session_factory(lambda: session)
+
+    system_settings.seed_system_settings()
+
+    assert session.added == []
+    assert session.commits == 0
+    assert session.close_calls == 2
+
+
+def test_cache_loading_uses_explicit_values_and_defaults():
+    explicit = PluginSetting(
+        plugin_name=system_settings.SYSTEM_PLUGIN_NAME,
+        key="EXPLICIT",
+        type="string",
+        value="chosen",
+        default_value="default",
+    )
+    fallback = PluginSetting(
+        plugin_name=system_settings.SYSTEM_PLUGIN_NAME,
+        key="FALLBACK",
+        type="string",
+        value=None,
+        default_value="default",
+    )
+    session = FakeSession([explicit, fallback])
+
+    system_settings._ensure_cache(session)
+    session.rows = []
+    system_settings._ensure_cache(session)
+
+    assert system_settings._CACHE == {
+        "EXPLICIT": "chosen",
+        "FALLBACK": "default",
+    }
+    assert len(session.executed) == 1
+
+
+def test_get_value_uses_environment_in_test_mode(monkeypatch):
+    monkeypatch.setenv("PYTEST_CURRENT_TEST", "active")
+    monkeypatch.setenv("TASK_LOOP_INTERVAL", "1.25")
+    monkeypatch.setenv("TASK_DEBUG", "yes")
+    monkeypatch.setenv("CUSTOM_SETTING", "custom")
+
+    assert system_settings.get_value("TASK_LOOP_INTERVAL") == 1.25
+    assert system_settings.get_value("TASK_DEBUG") is True
+    assert system_settings.get_value("CUSTOM_SETTING") == "custom"
+    assert system_settings.get_value("MISSING", "fallback") == "fallback"
+
+
+def _disable_test_detection(monkeypatch):
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    monkeypatch.setenv("_", "python")
+    monkeypatch.setattr(sys, "argv", ["stash-ai-server"])
+
+
+def test_get_value_loads_database_cache_outside_test_mode(monkeypatch):
+    _disable_test_detection(monkeypatch)
+    row = PluginSetting(
+        plugin_name=system_settings.SYSTEM_PLUGIN_NAME,
+        key="SETTING",
+        type="string",
+        value="database",
+        default_value="default",
+    )
+    session = FakeSession([row])
+    system_settings.set_session_factory(lambda: session)
+
+    assert system_settings.get_value("SETTING", "fallback") == "database"
+    assert system_settings.get_value("MISSING", "fallback") == "fallback"
+    assert session.close_calls == 2
+
+
+def test_get_value_returns_default_for_database_failures(monkeypatch):
+    _disable_test_detection(monkeypatch)
+    unavailable = FakeSession(connection_error=RuntimeError("offline"))
+    system_settings.set_session_factory(lambda: unavailable)
+
+    assert system_settings.get_value("SETTING", "fallback") == "fallback"
+    assert unavailable.close_calls == 1
+
+    system_settings.set_session_factory(
+        lambda: (_ for _ in ()).throw(RuntimeError("open failed"))
+    )
+    assert system_settings.get_value("SETTING", "fallback") == "fallback"
+
+
+def test_set_value_updates_existing_row_and_cache():
+    row = PluginSetting(
+        plugin_name=system_settings.SYSTEM_PLUGIN_NAME,
+        key="TASK_DEBUG",
+        type="boolean",
+        value=False,
+    )
+    session = FakeSession([row])
+    system_settings.set_session_factory(lambda: session)
+
+    system_settings.set_value("TASK_DEBUG", "true")
+
+    assert row.value is True
+    assert session.added == []
+    assert session.commits == 1
+    assert session.close_calls == 1
+    assert system_settings._CACHE["TASK_DEBUG"] is True
+
+
+def test_set_value_creates_unknown_setting_and_invalidates_cache():
+    session = FakeSession()
+    system_settings.set_session_factory(lambda: session)
+
+    system_settings.set_value("CUSTOM_SETTING", 42)
+    system_settings._CACHE_LOADED = True
+    system_settings.invalidate_cache()
+
+    [created] = session.added
+    assert created.plugin_name == system_settings.SYSTEM_PLUGIN_NAME
+    assert created.key == "CUSTOM_SETTING"
+    assert created.type == "string"
+    assert created.label == "CUSTOM_SETTING"
+    assert created.value == 42
+    assert session.commits == 1
+    assert system_settings._CACHE["CUSTOM_SETTING"] == 42
+    assert system_settings._CACHE_LOADED is False

--- a/backend/tests/test_task_helpers_unit.py
+++ b/backend/tests/test_task_helpers_unit.py
@@ -1,0 +1,241 @@
+"""Unit tests for task handler metadata and chunked child task submission."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from stash_ai_server.actions.models import ContextInput
+from stash_ai_server.tasks import helpers
+from stash_ai_server.tasks.models import (
+    TaskPriority,
+    TaskSpec,
+    TaskStatus,
+    new_task,
+)
+
+
+def _parent(*, service: str = "service", cancel_requested: bool = False):
+    task = new_task(
+        "parent",
+        service,
+        TaskPriority.normal,
+        ContextInput(page="scenes", selected_ids=["1", "2"]),
+        {},
+    )
+    task.cancel_requested = cancel_requested
+    return task
+
+
+class FakeTaskManager:
+    def __init__(self, *, child_status=TaskStatus.completed):
+        self.child_status = child_status
+        self.tasks = {}
+        self.controllers = []
+        self.submissions = []
+        self.progress = []
+
+    def mark_controller(self, task):
+        self.controllers.append(task.id)
+        task.skip_concurrency = True
+
+    def submit(
+        self,
+        spec,
+        handler,
+        context,
+        params,
+        priority,
+        *,
+        group_id,
+    ):
+        child_id = f"child-{len(self.submissions) + 1}"
+        child = SimpleNamespace(
+            id=child_id,
+            group_id=group_id,
+            status=self.child_status,
+        )
+        self.tasks[child_id] = child
+        self.submissions.append(
+            {
+                "spec": spec,
+                "handler": handler,
+                "context": context,
+                "params": params,
+                "priority": priority,
+                "group_id": group_id,
+            }
+        )
+        return child
+
+    def emit_progress(self, task, payload):
+        self.progress.append((task.id, payload))
+
+
+def test_task_handler_attaches_task_spec():
+    @helpers.task_handler(id="child", service="declared")
+    async def handler(*_args):
+        return None
+
+    assert handler._task_spec == TaskSpec(id="child", service="declared")
+
+
+def test_chunk_helpers_build_expected_contexts_and_chunks():
+    parent_context = ContextInput(
+        page="scenes",
+        entity_id="parent",
+        is_detail_view=True,
+        selected_ids=["1", "2"],
+    )
+
+    single = helpers._make_child_context(["1"], parent_context)
+    multiple = helpers._make_child_context(["1", "2"], parent_context)
+
+    assert single.entity_id == "1"
+    assert single.selected_ids == []
+    assert single.is_detail_view is True
+    assert multiple.entity_id is None
+    assert multiple.selected_ids == ["1", "2"]
+    assert list(helpers._chunk_items([1, 2, 3], 2)) == [[1, 2], [3]]
+    assert list(helpers._chunk_items([1, 2], 0)) == [[1], [2]]
+    assert list(helpers._chunk_items([], 2)) == []
+
+
+@pytest.mark.asyncio
+async def test_spawn_chunked_tasks_returns_early_for_empty_input(monkeypatch):
+    manager = FakeTaskManager()
+    monkeypatch.setattr(helpers, "task_manager", manager)
+
+    result = await helpers.spawn_chunked_tasks(
+        parent_task=_parent(),
+        parent_context=ContextInput(page="scenes"),
+        handler=lambda *_: None,
+        items=[],
+        chunk_size=2,
+        hold_children=False,
+    )
+
+    assert result == {"spawned": [], "count": 0, "held": False}
+    assert manager.submissions == []
+
+
+@pytest.mark.asyncio
+async def test_spawn_chunked_tasks_requires_handler_metadata(monkeypatch):
+    monkeypatch.setattr(helpers, "task_manager", FakeTaskManager())
+
+    with pytest.raises(ValueError, match="missing task metadata"):
+        await helpers.spawn_chunked_tasks(
+            parent_task=_parent(),
+            parent_context=ContextInput(page="scenes"),
+            handler=lambda *_: None,
+            items=["1"],
+            chunk_size=1,
+        )
+
+
+@pytest.mark.asyncio
+async def test_spawn_chunked_tasks_infers_service_and_returns_without_holding(
+    monkeypatch,
+):
+    manager = FakeTaskManager(child_status=TaskStatus.queued)
+    monkeypatch.setattr(helpers, "task_manager", manager)
+
+    @helpers.task_handler(id="child")
+    async def handler(*_args):
+        return None
+
+    parent = _parent(service="parent-service")
+    result = await helpers.spawn_chunked_tasks(
+        parent_task=parent,
+        parent_context=ContextInput(page="scenes"),
+        handler=handler,
+        items=["1", "2", "3"],
+        chunk_size=2,
+        params={"threshold": 0.5},
+        priority=TaskPriority.low,
+        hold_children=False,
+    )
+
+    assert result == {
+        "spawned": ["child-1", "child-2"],
+        "count": 2,
+        "held": False,
+        "min_hold": None,
+    }
+    assert manager.controllers == [parent.id]
+    assert [entry["spec"].service for entry in manager.submissions] == [
+        "parent-service",
+        "parent-service",
+    ]
+    assert manager.submissions[0]["context"].selected_ids == ["1", "2"]
+    assert manager.submissions[1]["context"].entity_id == "3"
+    assert all(
+        entry["params"] == {"threshold": 0.5}
+        for entry in manager.submissions
+    )
+    assert all(
+        entry["priority"] is TaskPriority.low for entry in manager.submissions
+    )
+
+
+@pytest.mark.asyncio
+async def test_spawn_chunked_tasks_holds_completed_children(monkeypatch):
+    manager = FakeTaskManager(child_status=TaskStatus.completed)
+    monkeypatch.setattr(helpers, "task_manager", manager)
+    custom_contexts = []
+
+    def context_factory(chunk, parent_context):
+        custom_contexts.append((list(chunk), parent_context.page))
+        return ContextInput(page="images", selected_ids=list(chunk))
+
+    async def handler(*_args):
+        return None
+
+    parent = _parent()
+    result = await helpers.spawn_chunked_tasks(
+        parent_task=parent,
+        parent_context=ContextInput(page="scenes"),
+        handler=handler,
+        items=["1", "2"],
+        chunk_size=1,
+        task_spec=TaskSpec(id="explicit", service="explicit-service"),
+        context_factory=context_factory,
+    )
+
+    assert result == {
+        "spawned": ["child-1", "child-2"],
+        "count": 2,
+        "held": True,
+    }
+    assert custom_contexts == [(["1"], "scenes"), (["2"], "scenes")]
+    assert manager.progress[-1] == (
+        parent.id,
+        {"completed": 2, "total": 2, "pending": 0},
+    )
+
+
+@pytest.mark.asyncio
+async def test_spawn_chunked_tasks_stops_holding_when_parent_is_cancelled(
+    monkeypatch,
+):
+    manager = FakeTaskManager(child_status=TaskStatus.running)
+    monkeypatch.setattr(helpers, "task_manager", manager)
+    parent = _parent(cancel_requested=True)
+    parent.skip_concurrency = True
+
+    result = await helpers.spawn_chunked_tasks(
+        parent_task=parent,
+        parent_context=ContextInput(page="scenes"),
+        handler=lambda *_: None,
+        items=["1"],
+        chunk_size=1,
+        task_spec=TaskSpec(id="child", service="service"),
+        mark_parent_controller=False,
+    )
+
+    assert result["held"] is True
+    assert manager.controllers == []
+    assert manager.progress[-1][1] == {
+        "completed": 0,
+        "total": 1,
+        "pending": 1,
+    }

--- a/backend/tests/test_websocket_manager_unit.py
+++ b/backend/tests/test_websocket_manager_unit.py
@@ -1,0 +1,197 @@
+"""Unit tests for WebSocket connection and task-event handling."""
+
+import asyncio
+import json
+from types import SimpleNamespace
+
+import pytest
+from fastapi import WebSocketDisconnect
+
+from stash_ai_server.api import ws as ws_api
+
+
+class FakeWebSocket:
+    def __init__(self, *, fail_send=False, receive_error=None):
+        self.fail_send = fail_send
+        self.receive_error = receive_error
+        self.accepted = 0
+        self.sent = []
+
+    async def accept(self):
+        self.accepted += 1
+
+    async def send_text(self, data):
+        if self.fail_send:
+            raise RuntimeError("send failed")
+        self.sent.append(data)
+
+    async def receive_text(self):
+        if self.receive_error is not None:
+            raise self.receive_error
+        return "ping"
+
+
+class FakeTask:
+    def __init__(self, identifier):
+        self.identifier = identifier
+
+    def summary(self):
+        return {"id": self.identifier}
+
+
+class FakeTaskManager:
+    def __init__(self, tasks=(), *, registration_error=None):
+        self.tasks = list(tasks)
+        self.registration_error = registration_error
+        self.listeners = []
+
+    def on_event(self, listener):
+        if self.registration_error is not None:
+            raise self.registration_error
+        self.listeners.append(listener)
+
+    def list(self):
+        return list(self.tasks)
+
+
+@pytest.fixture(autouse=True)
+def reset_websocket_globals(monkeypatch):
+    manager = ws_api.ConnectionManager()
+    monkeypatch.setattr(ws_api, "ws_manager", manager)
+    monkeypatch.setattr(ws_api, "_listener_registered", False)
+    monkeypatch.setattr(ws_api, "_task_manager_ref", None)
+    return manager
+
+
+@pytest.mark.asyncio
+async def test_connection_manager_connects_removes_and_broadcasts():
+    manager = ws_api.ConnectionManager()
+    healthy = FakeWebSocket()
+    stale = FakeWebSocket(fail_send=True)
+
+    await manager.connect(healthy)
+    await manager.connect(stale)
+    await manager.broadcast({"type": "update", "value": 1})
+
+    assert healthy.accepted == 1
+    assert stale.accepted == 1
+    assert [json.loads(payload) for payload in healthy.sent] == [
+        {"type": "update", "value": 1}
+    ]
+    assert manager.active == [healthy]
+
+
+@pytest.mark.asyncio
+async def test_task_event_listener_schedules_broadcast_on_running_loop(monkeypatch):
+    payloads = []
+
+    async def broadcast(payload):
+        payloads.append(payload)
+
+    monkeypatch.setattr(ws_api.ws_manager, "broadcast", broadcast)
+
+    ws_api._task_event_listener("completed", FakeTask("task-1"), None)
+    await asyncio.sleep(0)
+
+    assert payloads == [
+        {"type": "task.completed", "task": {"id": "task-1"}}
+    ]
+
+
+def test_task_event_listener_falls_back_to_asyncio_run(monkeypatch):
+    payloads = []
+
+    async def broadcast(payload):
+        payloads.append(payload)
+
+    def no_loop():
+        raise RuntimeError("no loop")
+
+    monkeypatch.setattr(ws_api.ws_manager, "broadcast", broadcast)
+    monkeypatch.setattr(
+        ws_api,
+        "asyncio",
+        SimpleNamespace(
+            get_running_loop=no_loop,
+            get_event_loop=no_loop,
+            run=asyncio.run,
+        ),
+    )
+
+    ws_api._task_event_listener("failed", FakeTask("task-2"), None)
+
+    assert payloads == [
+        {"type": "task.failed", "task": {"id": "task-2"}}
+    ]
+
+
+def test_listener_registration_is_idempotent_and_tracks_manager_changes():
+    first = FakeTaskManager()
+    second = FakeTaskManager()
+
+    ws_api._ensure_listener_registered(first)
+    ws_api._ensure_listener_registered(first)
+    ws_api._ensure_listener_registered(second)
+
+    assert first.listeners == [ws_api._task_event_listener]
+    assert second.listeners == [ws_api._task_event_listener]
+    assert ws_api._task_manager_ref is second
+
+
+def test_listener_registration_failure_does_not_mark_registered():
+    manager = FakeTaskManager(registration_error=RuntimeError("failed"))
+
+    ws_api._ensure_listener_registered(manager)
+
+    assert ws_api._listener_registered is False
+    assert ws_api._task_manager_ref is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "receive_error_type",
+    [WebSocketDisconnect, RuntimeError],
+)
+async def test_tasks_websocket_authenticates_sends_snapshots_and_cleans_up(
+    monkeypatch,
+    receive_error_type,
+):
+    socket = FakeWebSocket(receive_error=receive_error_type())
+    task_manager = FakeTaskManager([FakeTask("one"), FakeTask("two")])
+    auth_calls = []
+
+    async def enforce_auth(ws):
+        auth_calls.append(ws)
+
+    monkeypatch.setattr(ws_api, "enforce_shared_key_websocket", enforce_auth)
+
+    await ws_api.tasks_ws(socket, task_manager)
+
+    assert auth_calls == [socket]
+    assert socket.accepted == 1
+    assert [json.loads(payload) for payload in socket.sent] == [
+        {"type": "task.snapshot", "task": {"id": "one"}},
+        {"type": "task.snapshot", "task": {"id": "two"}},
+    ]
+    assert ws_api.ws_manager.active == []
+    assert task_manager.listeners == [ws_api._task_event_listener]
+
+
+@pytest.mark.asyncio
+async def test_tasks_websocket_ignores_snapshot_send_failures(monkeypatch):
+    socket = FakeWebSocket(
+        fail_send=True,
+        receive_error=WebSocketDisconnect(),
+    )
+    task_manager = FakeTaskManager([FakeTask("one")])
+
+    async def enforce_auth(_ws):
+        return None
+
+    monkeypatch.setattr(ws_api, "enforce_shared_key_websocket", enforce_auth)
+
+    await ws_api.tasks_ws(socket, task_manager)
+
+    assert socket.accepted == 1
+    assert socket.sent == []
+    assert ws_api.ws_manager.active == []


### PR DESCRIPTION
Adds backend unit coverage for API authentication, runtime refresh coordination, plugin loading, recommendations, health checks, Stash integration, WebSockets, interactions, and AI result persistence.

Coverage increases from 42.05% to 80.96% (5,400 of 6,670 statements).

The suite passes on Python 3.12, 3.13, and 3.14 with 427 passed and 76 skipped.
